### PR TITLE
Version 2.05

### DIFF
--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -1,0 +1,39 @@
+Version 2.05 will add four new cover page properties developed from the Script_Template repository.
+
+.PARAMETER CompanyAddress
+	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
+		The following Cover Pages have an Address field:
+			Banded
+			Contrast
+			Exposure
+			Filigree
+			Ion (Dark)
+			Retrospect
+			Semaphore
+			Tiles
+			ViewMaster
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CA.
+.PARAMETER CompanyEmail
+	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
+		The following Cover Pages have an Email field:
+			Facet
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CE.
+.PARAMETER CompanyFax
+	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
+		The following Cover Pages have a Fax field:
+			Contrast
+			Exposure
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CF.
+.PARAMETER CompanyPhone
+	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
+		The following Cover Pages have a Phone field:
+			Contrast
+			Exposure
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CPh.
+
+All the code verify the script parameters are set correctly will be removed. This "bug" was fixed in PowerShell V3.
+Version 7.14.1 support.

--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -1,4 +1,8 @@
 #Version 2.05
+#	Added additional error checking for Site version information
+#		If "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Citrix Desktop Delivery Controller" 
+#		is not found on the computer running the script, then look on the computer specified for -AdminAddress
+#		If still not found on that computer, abort the script
 #	Added back the WorkerGroup policy filter for XenApp 6.x
 #	Added Broker registry keys that can be set on Broker servers
 #		Added Function GetControllerRegistryKeys
@@ -17,7 +21,7 @@
 #		Company Phone
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
-#		This is the same as using the follwoing parameters:
+#		This is the same as using the following parameters:
 #			Administrators
 #			AppDisks
 #			Applications
@@ -42,6 +46,7 @@
 #	Added Version information to Controllers
 #	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fixed Function Check-LoadedModule
+#	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
@@ -52,3 +57,4 @@
 #	Updated Function ShowScriptOptions for the new Cover Page properties
 #	Updated Function UpdateDocumentProperties for the new Cover Page properties
 #	Updated help text
+#	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for

--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -13,6 +13,7 @@
 #		There are 315 registry keys and values that are checked and listed
 #		Updated Function OutputControllers
 #	Added Controller version information to the Controllers section
+#	Added "Database Size" to the Datastores output
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
@@ -53,8 +54,9 @@
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function ProcessScriptEnd for the new Cover Page properties
-#	Updated Function ShowScriptOptions for the new Cover Page properties
-#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated Function OutputDatastores to add database size
+#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
+#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
 #	Updated help text
 #	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for

--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -1,11 +1,34 @@
 #Version 2.05
 #	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added Broker registry keys that can be set on Broker servers
+#		Added Function GetControllerRegistryKeys
+#		Added Function Get-RegistryValue2
+#		Added Function Get-RegKeyToObject
+#		Added Function OutputControllerRegistryKeys
+#		Added new parameter BrokerRegistryKeys
+#		There are 315 registry keys and values that are checked and listed
+#		Updated Function OutputControllers
+#	Added Controller version information to the Controllers section
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added missing function validObject
+#	Added new parameter MaxDetails:
+#		This is the same as using the follwoing parameters:
+#			Administrators
+#			AppDisks
+#			Applications
+#			BrokerRegistryKeys
+#			DeliveryGroups
+#			HardWare
+#			Hosting
+#			Logging
+#			MachineCatalogs
+#			Policies
+#			StoreFront
 #	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
@@ -16,13 +39,16 @@
 #		Logoff Checker Startup Delay (seconds)
 #		Profile Streaming Exclusion list - directories
 #	Added to Delivery Group, LicenseModel and ProductCode
-#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
-#	Fix Function Check-LoadedModule
-#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
-#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
-#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
-#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Update Function ProcessScriptEnd for the new Cover Page properties
-#	Update Function ShowScriptOptions for the new Cover Page properties
-#	Update Function UpdateDocumentProperties for the new Cover Page properties
-#	Update help text
+#	Added Version information to Controllers
+#	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
+#	Fixed Function Check-LoadedModule
+#	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fixed numerous issues in the Policies section
+#	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
+#	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Reordered the parameters in the help text and parameter list so they match and are grouped better
+#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Updated Function ProcessScriptEnd for the new Cover Page properties
+#	Updated Function ShowScriptOptions for the new Cover Page properties
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated help text

--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -1,39 +1,28 @@
-Version 2.05 will add four new cover page properties developed from the Script_Template repository.
-
-.PARAMETER CompanyAddress
-	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
-		The following Cover Pages have an Address field:
-			Banded
-			Contrast
-			Exposure
-			Filigree
-			Ion (Dark)
-			Retrospect
-			Semaphore
-			Tiles
-			ViewMaster
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CA.
-.PARAMETER CompanyEmail
-	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
-		The following Cover Pages have an Email field:
-			Facet
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CE.
-.PARAMETER CompanyFax
-	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
-		The following Cover Pages have a Fax field:
-			Contrast
-			Exposure
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CF.
-.PARAMETER CompanyPhone
-	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
-		The following Cover Pages have a Phone field:
-			Contrast
-			Exposure
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CPh.
-
-All the code verify the script parameters are set correctly will be removed. This "bug" was fixed in PowerShell V3.
-Version 7.14.1 support.
+#Version 2.05
+#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
+#	Added four new Cover Page properties
+#		Company Address
+#		Company Email
+#		Company Fax
+#		Company Phone
+#	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
+#	Added support for version 7.14
+#	Added the following new Computer policy settings:
+#		Application Launch Wait Timeout
+#		Enable monitoring of application failures
+#		Enable monitoring of application failures on Desktop OS VDAs
+#		List of applications excluded from failure monitoring
+#		Logoff Checker Startup Delay (seconds)
+#		Profile Streaming Exclusion list - directories
+#	Added to Delivery Group, LicenseModel and ProductCode
+#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
+#	Fix Function Check-LoadedModule
+#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
+#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Update Function ProcessScriptEnd for the new Cover Page properties
+#	Update Function ShowScriptOptions for the new Cover Page properties
+#	Update Function UpdateDocumentProperties for the new Cover Page properties
+#	Update help text

--- a/2.05ReadMe
+++ b/2.05ReadMe
@@ -20,6 +20,7 @@
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added loading the SQL Server assembly so the database size calculations work consistently (thanks to Michael B. Smith)
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
 #		This is the same as using the following parameters:
@@ -50,11 +51,16 @@
 #	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
+#	Fixed the "CPU Usage", "Disk Usage", and "Memory Usage" policy settings
+#		When those settings are Disabled, they are stored as Enabled with a Value of -1
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function OutputDatastores to add database size
+#	Updated Function OutputDatastores to:
+#		Add database size
+#		Fix output for mirrored databases
+#		Check if SQL Server assembly is loaded before calculating database size
 #	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
 #	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
 #	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -31157,10 +31157,10 @@ Function ProcessScriptSetup
 	Write-Verbose "$(Get-Date): Major version $($MajorVersion)"
 	Write-Verbose "$(Get-Date): Minor version $($MinorVersion)"
 
-	#first check to make sure this is a Site between 7.0 and 7.7
+	#first check to make sure this is a 7.x Site
 	If($MajorVersion -eq 7)
 	{
-		#this is a XenDesktop 7.x Site, now test to make sure it is less than 7.8
+		#this is a XenDesktop 7.x Site, now test to see if it is less than 7.8
 		If($MinorVersion -lt 8)
 		{
 			Write-Warning "You are running version $($value)"
@@ -31172,6 +31172,8 @@ Function ProcessScriptSetup
 	ElseIf($MajorVersion -eq 0 -and $MinorVersion -eq 0)
 	{
 		#something is wrong, we shouldn't be here
+		Write-Verbose "$(Get-Date): Something bad happened. We shouldn't be here. Could not find the version information.`n`nScript cannot continue`n"
+		AbortScript
 	}
 	Else
 	{
@@ -31205,7 +31207,7 @@ Function ProcessScriptSetup
 	Write-Verbose "$(Get-Date): Initial Site data has been gathered"
 	
 	#added 25-Jun-2017 with a lot of help from Michael B. Smith
-	#make sure the SQL Server assemble is loaded, if not, later on don't bother calculating the various database sizes
+	#make sure the SQL Server assembly is loaded, if not, later on don't bother calculating the various database sizes
 	Write-Verbose "$(Get-Date): Loading SQL Server Assembly"
 	[bool]$Script:SQLServerLoaded = $False
 	
@@ -31219,24 +31221,6 @@ Function ProcessScriptSetup
 	{
 		Write-Verbose "$(Get-Date): `tSQL Server Assembly successefully loaded"
 		$Script:SQLServerLoaded = $True
-		$version = ( $asm.FullName.Split( ',' ).Trim() )[1]
-		$verNum = $version.SubString( $version.IndexOf( '=' ) + 1 )
-		$objVer = $verNum –as [Version]
-		$Major = $objVer.Major
-		$Minor = $objVer.Minor
-		$SQLVer = ""
-		Switch ($Major)
-		{
-			8						{$SQLVer = "SQL Server 2000"; Break}
-			9						{$SQLVer = "SQL Server 2005"; Break}
-			{10 -and $Minor -eq 0}	{$SQLVer = "SQL Server 2008"}
-			{10 -and $Minor -eq 5}	{$SQLVer = "SQL Server 2008 R2"}
-			11						{$SQLVer = "SQL Server 2012"; Break}
-			12						{$SQLVer = "SQL Server 2014"; Break}
-			13						{$SQLVer = "SQL Server 2016"; Break}
-			Default					{$SQLVer = "Unable to determine SQL Server version"; Break}
-		}
-		Write-Verbose "$(Get-Date): `t`tRunning SQL Server version $($Major).$($Minor) $($SQLVer)"
 	}
 }
 #endregion

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 3.0
+﻿#Requires -Version 3.0
 #This File is in Unicode format.  Do not edit in an ASCII editor.
 
 #region help text
@@ -1000,12 +1000,14 @@ Param(
 # This script is based on the 1.20 script
 
 #Version 2.05
-#	Add four new Cover Page properties
+#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
+#	Added four new Cover Page properties
 #		Company Address
 #		Company Email
 #		Company Fax
 #		Company Phone
-#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
 #		Application Launch Wait Timeout
@@ -1017,6 +1019,8 @@ Param(
 #	Added to Delivery Group, LicenseModel and ProductCode
 #	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fix Function Check-LoadedModule
+#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
 #	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
 #	Update Function ProcessScriptEnd for the new Cover Page properties
@@ -10955,7 +10959,7 @@ Function OutputDeliveryGroupApplicationDetails
 {
 	Param([object] $Group)
 	
-	$AllApplications = Get-BrokerApplication -AssociatedDesktopGroupUid $Group.Uid
+	$AllApplications = Get-BrokerApplication @XDParams2 -AssociatedDesktopGroupUid $Group.Uid -SortBy "ApplicationName"
 	
 	If($? -and $Null -ne $AllApplications)
 	{
@@ -11599,7 +11603,7 @@ Function OutputDeliveryGroupApplicationGroups
 		$rowdata = @()
 	}
 	
-	$ApplicationGroups = Get-BrokerApplicationGroup @XDParams1 -AssociatedDesktopGroupUid $Group.Uid
+	$ApplicationGroups = Get-BrokerApplicationGroup @XDParams1 -AssociatedDesktopGroupUid $Group.Uid | Sort Name
 	
 	If($? -and $Null -ne $ApplicationGroups)
 	{
@@ -11686,7 +11690,7 @@ Function ProcessApplications
 	$Global:TotalPublishedApplications = 0
 	$Global:TotalAppvApplications = 0
 	
-	$AllApplications = Get-BrokerApplication @XDParams1 -SortBy Name
+	$AllApplications = Get-BrokerApplication @XDParams2 -SortBy "AdminFolderName,ApplicationName"
 	If($? -and $Null -ne $AllApplications)
 	{
 		OutputApplications $AllApplications
@@ -11763,6 +11767,7 @@ Function OutputApplications
 		If($MSWord -or $PDF)
 		{
 			$WordTableRowHash = @{
+			FolderName = $Application.AdminFolderName;
 			ApplicationName = $Application.ApplicationName; 
 			Description = $Application.Description; 
 			Location = $xLocation;
@@ -11772,6 +11777,7 @@ Function OutputApplications
 		}
 		ElseIf($Text)
 		{
+			Line 1 "Folder`t`t: " $Application.AdminFolderName
 			Line 1 "Name`t`t: " $Application.ApplicationName
 			Line 1 "Description`t: " $Application.Description
 			Line 1 "Location`t: " $xLocation
@@ -11781,6 +11787,7 @@ Function OutputApplications
 		ElseIf($HTML)
 		{
 			$rowdata += @(,(
+			$Application.AdminFolderName,$htmlwhite,
 			$Application.ApplicationName,$htmlwhite,
 			$Application.Description,$htmlwhite,
 			$xLocation,$htmlwhite,
@@ -11791,17 +11798,18 @@ Function OutputApplications
 	If($MSWord -or $PDF)
 	{
 		$Table = AddWordTable -Hashtable $AllApplicationsWordTable `
-		-Columns  ApplicationName,Description,Location,Enabled `
-		-Headers  "Name","Description","Location","State" `
+		-Columns  FolderName,ApplicationName,Description,Location,Enabled `
+		-Headers  "Folder","Name","Description","Location","State" `
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
 		SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
-		$Table.Columns.Item(1).Width = 175;
-		$Table.Columns.Item(2).Width = 170;
-		$Table.Columns.Item(3).Width = 100;
-		$Table.Columns.Item(4).Width = 55;
+		$Table.Columns.Item(1).Width = 100;
+		$Table.Columns.Item(2).Width = 145;
+		$Table.Columns.Item(3).Width = 125;
+		$Table.Columns.Item(4).Width = 80;
+		$Table.Columns.Item(5).Width = 50;
 
 		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -11812,13 +11820,14 @@ Function OutputApplications
 	ElseIf($HTML)
 	{
 		$columnHeaders = @(
+		'Folder',($htmlsilver -bor $htmlbold),
 		'Name',($htmlsilver -bor $htmlbold),
 		'Description',($htmlsilver -bor $htmlbold),
 		'Location',($htmlsilver -bor $htmlbold),
 		'State',($htmlsilver -bor $htmlbold))
 
 		$msg = ""
-		$columnWidths = @("175","170","100","55")
+		$columnWidths = @("100","145","125","80","50")
 		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "500"
 		WriteHTMLLine 0 0 " "
 	}
@@ -12490,7 +12499,7 @@ Function ProcessApplicationGroupDetails
 		ForEach($AppGroup in $ApplicationGroups)
 		{
 			Write-Verbose "$(Get-Date): `t`t`tAdding Application Group $($ApplicationGroup.Name)"
-#line 11950
+
 			$xEnabled = "No"
 			If($AppGroup.Enabled)
 			{
@@ -13355,7 +13364,7 @@ Function ProcessCitrixPolicies
 			}
 			ElseIf($? -and $Null -eq $Filters)
 			{
-				$txt = "$($Policy.PolicyName) policy has no filter settings"
+				$txt = "$($Policy.PolicyName) policy applies to all objects in the Site"
 				If($MSWord -or $PDF)
 				{
 					WriteWordLine 3 0 "Assigned to"
@@ -13374,7 +13383,7 @@ Function ProcessCitrixPolicies
 			}
 			ElseIf($? -and $Policy.PolicyName -eq "Unfiltered")
 			{
-				$txt = "Unfiltered policy has no filter settings"
+				$txt = "Unfiltered policy applies to all objects in the Site"
 				If($MSWord -or $PDF)
 				{
 					WriteWordLine 3 0 "Assigned to"
@@ -28518,31 +28527,40 @@ Function ProcessAppV
 	}
 	
 	Write-Verbose "$(Get-Date): `tRetrieving App-V configuration"
-	$AppvConfig = Get-BrokerMachineConfiguration @XDParams1 -Name appv*
+	$AppVConfigs = Get-BrokerMachineConfiguration @XDParams1 -Name appv* 4>$Null
 	
-	If($? -and $Null -ne $AppVConfig)
+	If($? -and $Null -ne $AppVConfigs)
 	{
 		Write-Verbose "$(Get-Date): `t`tRetrieving App-V server information"
-		$AppVs = Get-CtxAppVServer -ByteArray $Appvconfig[0].Policy -EA 0
-		If($? -and ($Null -ne $AppVs))
+		
+		$AppVs = @()
+		ForEach($AppVConfig in $AppVConfigs)
 		{
-			ForEach($AppV in $AppVs)
+			$AppV = Get-CtxAppVServer -ByteArray $AppVConfig.Policy -EA 0 4>$Null
+			If($? -and ($Null -ne $AppV))
 			{
-				OutputAppV $AppV
+				$obj = New-Object -TypeName PSObject
+				$obj | Add-Member -MemberType NoteProperty -Name MgmtServer	-Value $AppV.ManagementServer
+				$obj | Add-Member -MemberType NoteProperty -Name PubServer	-Value $AppV.PublishingServer
+				$AppVs += $obj
+			}
+			ElseIf($? -and ($Null -eq $AppV))
+			{
+				$txt = "There was no App-V server information found for $($AppVConfig.Policy)"
+				OutputWarning $txt
+			}
+			Else
+			{
+				$txt = "Unable to retrieve App-V information for $($AppVConfig.Policy)"
+				OutputWarning $txt
 			}
 		}
-		ElseIf($? -and ($Null -eq $AppVs))
-		{
-			$txt = "There was no App-V server information found"
-			OutputWarning $txt
-		}
-		Else
-		{
-			$txt = "Unable to retrieve App-V information"
-			OutputWarning $txt
-		}
+		
+		$AppVs = $AppVs | Sort MgmtServer
+		
+		OutputAppV $AppVs
 	}
-	ElseIf($? -and $Null -eq $AppVConfig)
+	ElseIf($? -and $Null -eq $AppVConfigs)
 	{
 		$txt = "App-V is not configured for this Site"
 		OutputWarning $txt
@@ -28557,21 +28575,53 @@ Function ProcessAppV
 
 Function OutputAppV
 {
-	Param([object]$AppV)
+	Param([object]$AppVs)
 	
 	Write-Verbose "$(Get-Date): `t`t`tOutput App-V server information"
 	If($MSWord -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{Data = "App-V management server"; Value = $AppV.ManagementServer; }
-		$ScriptInformation += @{Data = "App-V publishing server"; Value = $AppV.PublishingServer; }
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
+		[System.Collections.Hashtable[]] $AppVWordTable = @();
+	}
+	ElseIf($HTML)
+	{
+		$rowdata = @()
+	}
+	
+	ForEach($AppV in $AppVs)
+	{
+		Write-Verbose "$(Get-Date): `t`t`tAdding AppV Server $($AppV.MgmtServer)"
+
+		If($MSWord -or $PDF)
+		{
+			$WordTableRowHash = @{
+			MgmtServer = $AppV.MgmtServer; 
+			PubServer = $AppV.PubServer; 
+			}
+			$AppVWordTable += $WordTableRowHash;
+		}
+		ElseIf($Text)
+		{
+			Line 1 "App-V management server`t: " $AppV.MgmtServer
+			Line 1 "App-V publishing server`t: " $AppV.PubServer
+			Line 0 ""
+		}
+		ElseIf($HTML)
+		{
+			$rowdata += @(,(
+			$AppV.MgmtServer,$htmlwhite,
+			$AppV.PubServer,$htmlwhite))
+		}
+	}
+
+	If($MSWord -or $PDF)
+	{
+		$Table = AddWordTable -Hashtable $AppVWordTable `
+		-Columns  MgmtServer,PubServer `
+		-Headers  "App-V management server","App-V publishing server" `
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+		SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 250;
 		$Table.Columns.Item(2).Width = 250;
@@ -28582,21 +28632,15 @@ Function OutputAppV
 		$Table = $Null
 		WriteWordLine 0 0 ""
 	}
-	ElseIf($Text)
-	{
-		Line 0 "App-V management server: " $Appv.ManagementServer
-		Line 0 "App-V publishing server: " $AppV.PublishingServer
-		Line 0 ""
-	}
 	ElseIf($HTML)
 	{
-		$rowdata = @()
-		$columnHeaders = @("App-V management server",($htmlsilver -bor $htmlbold),$Appv.ManagementServer,$htmlwhite)
-		$rowdata += @(,('App-V publishing server',($htmlsilver -bor $htmlbold),$AppV.PublishingServer,$htmlwhite))
+		$columnHeaders = @(
+		'App-V management server',($htmlsilver -bor $htmlbold),
+		'App-V publishing server',($htmlsilver -bor $htmlbold))
 
 		$msg = ""
 		$columnWidths = @("250","250")
-		FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "500"
 		WriteHTMLLine 0 0 " "
 	}
 }

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -83,35 +83,35 @@
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
 		The following Cover Pages have an Address field:
-			Banded
-			Contrast
-			Exposure
-			Filigree
-			Ion (Dark)
-			Retrospect
-			Semaphore
-			Tiles
-			ViewMaster
+			Banded (Word 2013/2016)
+			Contrast (Word 2010)
+			Exposure (Word 2010)
+			Filigree (Word 2013/2016)
+			Ion (Dark) (Word 2013/2016)
+			Retrospect (Word 2013/2016)
+			Semaphore (Word 2013/2016)
+			Tiles (Word 2010)
+			ViewMaster (Word 2013/2016)
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CA.
 .PARAMETER CompanyEmail
 	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
 		The following Cover Pages have an Email field:
-			Facet
+			Facet (Word 2013/2016)
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CE.
 .PARAMETER CompanyFax
 	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
 		The following Cover Pages have a Fax field:
-			Contrast
-			Exposure
+			Contrast (Word 2010)
+			Exposure (Word 2010)
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CF.
 .PARAMETER CompanyPhone
 	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
 		The following Cover Pages have a Phone field:
-			Contrast
-			Exposure
+			Contrast (Word 2010)
+			Exposure (Word 2010)
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CPh.
 .PARAMETER CoverPage
@@ -1005,17 +1005,17 @@ Param(
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added back the WorkerGroup policy filter for XenApp 6.x
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
 #		Application Launch Wait Timeout
 #		Enable monitoring of application failures
 #		Enable monitoring of application failures on Desktop OS VDAs
 #		List of applications excluded from failure monitoring
-#		Logoff Checker Startup Delay
-#		Profile Streaming Exclusion list - directories (Enable/Disable)
-#		Profile Streaming Exclusion list - directories (Enable with list of folders/Disable)
+#		Logoff Checker Startup Delay (seconds)
+#		Profile Streaming Exclusion list - directories
 #	Added to Delivery Group, LicenseModel and ProductCode
-#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fix Function Check-LoadedModule
 #	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
@@ -5200,7 +5200,7 @@ Function ShowScriptOptions
 	Write-Verbose "$(Get-Date): DeliveryGroups  : $($DeliveryGroups)"
 	If($Dev)
 	{
-		Write-Verbose "$(Get-Date): DevErrorFile  : $($Script:DevErrorFile)"
+		Write-Verbose "$(Get-Date): DevErrorFile    : $($Script:DevErrorFile)"
 	}
 	Write-Verbose "$(Get-Date): DGUtilization   : $($DeliveryGroupsUtilization)"
 	Write-Verbose "$(Get-Date): Filename1       : $($Script:filename1)"
@@ -5244,11 +5244,11 @@ Function ShowScriptOptions
 	Write-Verbose "$(Get-Date): PSUICulture     : $($PSUICulture)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Word language : $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Word version  : $($Script:WordProduct)"
+		Write-Verbose "$(Get-Date): Word language   : $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date): Word version    : $($Script:WordProduct)"
 	}
 	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Script start  : $($Script:StartTime)"
+	Write-Verbose "$(Get-Date): Script start    : $($Script:StartTime)"
 	Write-Verbose "$(Get-Date): "
 	Write-Verbose "$(Get-Date): "
 }
@@ -13353,42 +13353,58 @@ Function ProcessCitrixPolicies
 					}
 				}
 			}
+			ElseIf($? -and $Null -eq $Filters)
+			{
+				$txt = "$($Policy.PolicyName) policy has no filter settings"
+				If($MSWord -or $PDF)
+				{
+					WriteWordLine 3 0 "Assigned to"
+					WriteWordLine 0 1 $txt
+				}
+				ElseIf($Text)
+				{
+					Line 0 "Assigned to"
+					Line 1 $txt
+				}
+				ElseIf($HTML)
+				{
+					WriteHTMLLine 3 0 "Assigned to"
+					WriteHTMLLine 0 1 $txt
+				}
+			}
+			ElseIf($? -and $Policy.PolicyName -eq "Unfiltered")
+			{
+				$txt = "Unfiltered policy has no filter settings"
+				If($MSWord -or $PDF)
+				{
+					WriteWordLine 3 0 "Assigned to"
+					WriteWordLine 0 1 $txt
+				}
+				ElseIf($Text)
+				{
+					Line 0 "Assigned to"
+					Line 1 $txt
+				}
+				ElseIf($HTML)
+				{
+					WriteHTMLLine 3 0 "Assigned to"
+					WriteHTMLLine 0 1 $txt
+				}
+			}
 			Else
 			{
-				If($Policy.PolicyName -eq "Unfiltered")
+				$txt = "Unable to retrieve Filter settings"
+				If($MSWord -or $PDF)
 				{
-					$txt = "Unfiltered policy has no filter settings"
-					If($MSWord -or $PDF)
-					{
-						WriteWordLine 3 0 "Assigned to"
-						WriteWordLine 0 1 $txt
-					}
-					ElseIf($Text)
-					{
-						Line 0 "Assigned to"
-						Line 1 $txt
-					}
-					ElseIf($HTML)
-					{
-						WriteHTMLLine 3 0 "Assigned to"
-						WriteHTMLLine 0 1 $txt
-					}
+					WriteWordLine 0 1 $txt
 				}
-				Else
+				ElseIf($Text)
 				{
-					$txt = "Unable to retrieve Filter settings"
-					If($MSWord -or $PDF)
-					{
-						WriteWordLine 0 1 $txt
-					}
-					ElseIf($Text)
-					{
-						Line 1 $txt
-					}
-					ElseIf($HTML)
-					{
-						WriteHTMLLine 0 1 $txt
-					}
+					Line 1 $txt
+				}
+				ElseIf($HTML)
+				{
+					WriteHTMLLine 0 1 $txt
 				}
 			}
 			
@@ -14041,7 +14057,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting IcaListenerTimeout State ) -and ($Setting.IcaListenerTimeout.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\ICA listener connection timeout"
+						$txt = "ICA\ICA listener connection timeout (milliseconds)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -14107,7 +14123,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting LogoffCheckerStartupDelay State ) -and ($Setting.LogoffCheckerStartupDelay.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Logoff Checker Startup Delay"
+						$txt = "ICA\Logoff Checker Startup Delay (seconds)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -14972,7 +14988,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting USBBandwidthLimit State ) -and ($Setting.USBBandwidthLimit.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Bandwidth\Client USB device redirection bandwidth limit"
+						$txt = "ICA\Bandwidth\Client USB device redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -15506,7 +15522,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting IcaRoundTripCalculationInterval State ) -and ($Setting.IcaRoundTripCalculationInterval.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\End User Monitoring\ICA round trip calculation interval"
+						$txt = "ICA\End User Monitoring\ICA round trip calculation interval (seconds)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -18024,7 +18040,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting UpsPrintStreamInputBandwidthLimit State ) -and ($Setting.UpsPrintStreamInputBandwidthLimit.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Printing\Universal Print Server\Universal Print Server print stream input bandwidth limit (kbps)"
+						$txt = "ICA\Printing\Universal Print Server\Universal Print Server print stream input bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -18125,7 +18141,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting PrintServersOutOfServiceThreshold State ) -and ($Setting.PrintServersOutOfServiceThreshold.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Printing\Universal Print Server\Universal Print Servers out-of-service threshold"
+						$txt = "ICA\Printing\Universal Print Server\Universal Print Servers out-of-service threshold (seconds)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -22763,7 +22779,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting MaxLogSize_Part State ) -and ($Setting.MaxLogSize_Part.State -ne "NotConfigured"))
 					{
-						$txt = "Profile Management\Log settings\Maximum size of the log file"
+						$txt = "Profile Management\Log settings\Maximum size of the log file (bytes)"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -23500,28 +23516,6 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.PSEnabled.State 
-						}
-					}
-					If((validStateProp $Setting StreamingExclusionList State ) -and ($Setting.StreamingExclusionList.State -ne "NotConfigured"))
-					{
-						$txt = "Profile Management\Streamed user profiles\Profile Streaming Exclusion list - directories"
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $Setting.StreamingExclusionList.State;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$Setting.StreamingExclusionList.State,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $Setting.StreamingExclusionList.State 
 						}
 					}
 					If((validStateProp $Setting StreamingExclusionList_Part State ) -and ($Setting.StreamingExclusionList_Part.State -ne "NotConfigured"))

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -936,7 +936,7 @@
 	NAME: XD7_Inventory_V2.ps1
 	VERSION: 2.05
 	AUTHOR: Carl Webster
-	LASTEDIT: June 24, 2017
+	LASTEDIT: June 25, 2017
 #>
 
 #endregion
@@ -1150,6 +1150,7 @@ Param(
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added loading the SQL Server assembly so the database size calculations work consistently (thanks to Michael B. Smith)
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
 #		This is the same as using the following parameters:
@@ -1180,17 +1181,21 @@ Param(
 #	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
+#	Fixed the "CPU Usage", "Disk Usage", and "Memory Usage" policy settings
+#		When those settings are Disabled, they are stored as Enabled with a Value of -1
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function OutputDatastores to add database size
+#	Updated Function OutputDatastores to:
+#		Add database size
+#		Fix output for mirrored databases
+#		Check if SQL Server assembly is loaded before calculating database size
 #	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
 #	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
 #	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
 #	Updated help text
 #	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for
-#	
 
 #Version 2.04 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM
@@ -20212,50 +20217,41 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting CPUUsage State ) -and ($Setting.CPUUsage.State -ne "NotConfigured"))
 					{
 						$txt = "Load Management\CPU usage"
+						$tmp = ""
+						If($Setting.CPUUsage.State -eq "Enabled")
+						{
+							If($Setting.CPUUsage.Value -eq -1)
+							{
+								$tmp = "Disabled"
+							}
+							Else
+							{
+								$tmp = "Report full load $($Setting.CPUUsage.Value)(%)"
+							}
+						}
+						Else
+						{
+							$tmp = "Disabled"
+						}
 						If($MSWord -or $PDF)
 						{
 							If($Setting.CPUUsage.State -eq "Enabled")
 							{
 								$WordTableRowHash = @{
 								Text = $txt;
-								Value = "Report full load $($Setting.CPUUsage.Value)(%)";
+								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
-							}
-							Else
-							{
-								$WordTableRowHash = @{
-								Text = $txt;
-								Value = $Setting.CPUUsage.State;
-								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 						}
 						ElseIf($HTML)
 						{
-							If($Setting.CPUUsage.State -eq "Enabled")
-							{
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								"Report full load $($Setting.CPUUsage.Value)(%)",$htmlwhite))
-							}
-							Else
-							{
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								$Setting.CPUUsage.State,$htmlwhite))
-							}
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							If($Setting.CPUUsage.State -eq "Enabled")
-							{
-								OutputPolicySetting $txt $Setting.CPUUsage.State 
-							}
-							Else
-							{
-								OutputPolicySetting $txt "Report full load $($Setting.CPUUsage.Value)(%)" 
-							}
+							OutputPolicySetting $txt $tmp
 						}
 					}
 					If((validStateProp $Setting CPUUsageExcludedProcessPriority State ) -and ($Setting.CPUUsageExcludedProcessPriority.State -ne "NotConfigured"))
@@ -20317,7 +20313,14 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						If($Setting.DiskUsage.State -eq "Enabled")
 						{
-							$tmp = "Report 75% load (disk queue length): $($Setting.DiskUsage.Value)"
+							If($Setting.DiskUsage.Value -eq -1)
+							{
+								$tmp = "Disabled"
+							}
+							Else
+							{
+								$tmp = "Report 75% load (disk queue length): $($Setting.DiskUsage.Value)"
+							}
 						}
 						Else
 						{
@@ -20396,7 +20399,14 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						If($Setting.MemoryUsage.State -eq "Enabled")
 						{
-							$tmp = "Report full load (%): $($Setting.MemoryUsage.Value)"
+							If($Setting.MemoryUsage.Value -eq -1)
+							{
+								$tmp = "Disabled"
+							}
+							Else
+							{
+								$tmp = "Report full load (%): $($Setting.MemoryUsage.Value)"
+							}
 						}
 						Else
 						{
@@ -26022,6 +26032,7 @@ Function OutputConfigLogPreferences
 	$LogSQLServerPrincipalName = ""
 	$LogSQLServerMirrorName = ""
 	$LogDatabaseName = ""
+	[string]$dbsize = "Unable to determine database size"
 	$LogDBs = Get-LogDataStore @XDParams1
 
 	If($? -and ($Null -ne $LogDBs))
@@ -26054,10 +26065,13 @@ Function OutputConfigLogPreferences
 
 	#get database size
 	
-	$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
-	$db = New-Object Microsoft.SqlServer.Management.Smo.Database
-	$db = $SQLsrv.Databases.Item("$($LogDatabaseName)")
-	[string]$dbsize = "{0:F2} MB" -f $db.size
+	If($Script:SQLServerLoaded)
+	{
+		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
+		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+		$db = $SQLsrv.Databases.Item("$($LogDatabaseName)")
+		[string]$dbsize = "{0:F2} MB" -f $db.size
+	}
 	
 	If($Preferences.Enabled -eq "Enabled" -or $Preferences.Enabled -eq "Mandatory")
 	{
@@ -26405,6 +26419,7 @@ Function OutputDatastores
 	#only need what is between the = and ;
 	
 	#24-Jun-2017 add Database Size to the output
+	#25-Jun-2017 add checking if the SQL Server assembly loaded before calculating the database size
 	Write-Verbose "$(Get-Date): `tRetrieving database connection data"
 	Write-Verbose "$(Get-Date): `t`tConfiguration database"
 	$ConfigSQLServerPrincipalName = ""
@@ -26429,10 +26444,14 @@ Function OutputDatastores
 				"Initial Catalog"			{$ConfigDatabaseName = $Pair[1]; Break}
 			}
 		}
-		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
-		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
-		$db = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
-		$ConfigDBSize = "{0:F2} MB" -f $db.size
+
+		If($Script:SQLServerLoaded)
+		{
+			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
+			$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+			$db = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
+			$ConfigDBSize = "{0:F2} MB" -f $db.size
+		}
 	}
 	Else
 	{
@@ -26468,10 +26487,14 @@ Function OutputDatastores
 				}
 			}
 		}
-		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
-		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
-		$db = $SQLsrv.Databases.Item("$($LogDatabaseName)")
-		$LogDBSize = "{0:F2} MB" -f $db.size
+
+		If($Script:SQLServerLoaded)
+		{
+			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
+			$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+			$db = $SQLsrv.Databases.Item("$($LogDatabaseName)")
+			$LogDBSize = "{0:F2} MB" -f $db.size
+		}
 	}
 	Else
 	{
@@ -26511,10 +26534,14 @@ Function OutputDatastores
 				}
 			}
 		}
-		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerPrincipalName)")
-		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
-		$db = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
-		$MonitorDBSize = "{0:F2} MB" -f $db.size
+
+		If($Script:SQLServerLoaded)
+		{
+			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerPrincipalName)")
+			$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+			$db = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
+			$MonitorDBSize = "{0:F2} MB" -f $db.size
+		}
 		
 		$MonitorConfig = $Null
 		$MonitorConfig = Get-MonitorConfiguration @XDParams1
@@ -31176,6 +31203,41 @@ Function ProcessScriptSetup
 		"All"			{[string]$Script:Title = "Inventory Report for the $($Script:XDSiteName) Site"; Break}
 	}
 	Write-Verbose "$(Get-Date): Initial Site data has been gathered"
+	
+	#added 25-Jun-2017 with a lot of help from Michael B. Smith
+	#make sure the SQL Server assemble is loaded, if not, later on don't bother calculating the various database sizes
+	Write-Verbose "$(Get-Date): Loading SQL Server Assembly"
+	[bool]$Script:SQLServerLoaded = $False
+	
+	$asm = [reflection.assembly]::loadwithpartialname('microsoft.sqlserver.smo')
+	If( $null –eq $asm )
+	{
+		Write-Verbose "$(Get-Date): `tSQL Server Assembly could not be loaded"
+		$Script:SQLServerLoaded = $False
+	}
+	Else
+	{
+		Write-Verbose "$(Get-Date): `tSQL Server Assembly successefully loaded"
+		$Script:SQLServerLoaded = $True
+		$version = ( $asm.FullName.Split( ',' ).Trim() )[1]
+		$verNum = $version.SubString( $version.IndexOf( '=' ) + 1 )
+		$objVer = $verNum –as [Version]
+		$Major = $objVer.Major
+		$Minor = $objVer.Minor
+		$SQLVer = ""
+		Switch ($Major)
+		{
+			8						{$SQLVer = "SQL Server 2000"; Break}
+			9						{$SQLVer = "SQL Server 2005"; Break}
+			{10 -and $Minor -eq 0}	{$SQLVer = "SQL Server 2008"}
+			{10 -and $Minor -eq 5}	{$SQLVer = "SQL Server 2008 R2"}
+			11						{$SQLVer = "SQL Server 2012"; Break}
+			12						{$SQLVer = "SQL Server 2014"; Break}
+			13						{$SQLVer = "SQL Server 2016"; Break}
+			Default					{$SQLVer = "Unable to determine SQL Server version"; Break}
+		}
+		Write-Verbose "$(Get-Date): `t`tRunning SQL Server version $($Major).$($Minor) $($SQLVer)"
+	}
 }
 #endregion
 
@@ -31402,4 +31464,4 @@ UpdateDocumentProperties $AbstractTitle $SubjectTitle
 ProcessDocumentOutput
 
 ProcessScriptEnd
-#endregionn
+#endregionnn

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 3.0
+#Requires -Version 3.0
 #This File is in Unicode format.  Do not edit in an ASCII editor.
 
 #region help text
@@ -80,6 +80,40 @@
 	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated 
 	on the computer running the script.
 	This parameter has an alias of CN.
+.PARAMETER CompanyAddress
+	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
+		The following Cover Pages have an Address field:
+			Banded
+			Contrast
+			Exposure
+			Filigree
+			Ion (Dark)
+			Retrospect
+			Semaphore
+			Tiles
+			ViewMaster
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CA.
+.PARAMETER CompanyEmail
+	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
+		The following Cover Pages have an Email field:
+			Facet
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CE.
+.PARAMETER CompanyFax
+	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
+		The following Cover Pages have a Fax field:
+			Contrast
+			Exposure
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CF.
+.PARAMETER CompanyPhone
+	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
+		The following Cover Pages have a Phone field:
+			Contrast
+			Exposure
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CPh.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
 	Only Word 2010, 2013 and 2016 are supported.
@@ -628,6 +662,30 @@
 		Carl Webster for the User Name (alias UN).
 		The computer running the script for the AdminAddress.
 .EXAMPLE
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" `
+	-CoverPage Exposure -UserName "Dr. Watson" `
+	-CompanyAddress "221B Baker Street, London, England" `
+	-CompanyFax "+44 1753 276600" `
+	-CompanyPhone "+44 1753 276200"
+
+	Will use:
+		Sherlock Holmes Consulting for the Company Name.
+		Exposure for the Cover Page format.
+		Dr. Watson for the User Name.
+		221B Baker Street, London, England for the Company Address.
+		+44 1753 276600 for the Company Fax.
+		+44 1753 276200 for the Compnay Phone.
+.EXAMPLE
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" `
+	-CoverPage Facet -UserName "Dr. Watson" `
+	-CompanyEmail SuperSleuth@SherlockHolmes.com
+
+	Will use:
+		Sherlock Holmes Consulting for the Company Name.
+		Facet for the Cover Page format.
+		Dr. Watson for the User Name.
+		SuperSleuth@SherlockHolmes.com for the Compnay Email.
+.EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -AddDateTime
 	
 	Will use all Default values.
@@ -751,13 +809,13 @@
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
-	No objects are output from this script.  This script creates a Word, PDF
-	plain text or HTML document.
+	No objects are output from this script.  
+	This script creates a Word, PDF, plain text, or HTML document.
 .NOTES
 	NAME: XD7_Inventory_V2.ps1
-	VERSION: 2.04
+	VERSION: 2.05
 	AUTHOR: Carl Webster
-	LASTEDIT: March 6, 2017
+	LASTEDIT: June 12, 2017
 #>
 
 #endregion
@@ -868,6 +926,34 @@ Param(
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("CA")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyAddress="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("CE")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyEmail="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("CF")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyFax="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("CPh")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyPhone="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("CP")]
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
@@ -912,6 +998,31 @@ Param(
 #started updating for version 7.8+ on April 17, 2016
 
 # This script is based on the 1.20 script
+
+#Version 2.05
+#	Add four new Cover Page properties
+#		Company Address
+#		Company Email
+#		Company Fax
+#		Company Phone
+#	Added support for version 7.14
+#	Added the following new Computer policy settings:
+#		Application Launch Wait Timeout
+#		Enable monitoring of application failures
+#		Enable monitoring of application failures on Desktop OS VDAs
+#		List of applications excluded from failure monitoring
+#		Logoff Checker Startup Delay
+#		Profile Streaming Exclusion list - directories (Enable/Disable)
+#		Profile Streaming Exclusion list - directories (Enable with list of folders/Disable)
+#	Added to Delivery Group, LicenseModel and ProductCode
+#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Fix Function Check-LoadedModule
+#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Update Function ProcessScriptEnd for the new Cover Page properties
+#	Update Function ShowScriptOptions for the new Cover Page properties
+#	Update Function UpdateDocumentProperties for the new Cover Page properties
+#	Update help text
 
 #Version 2.04 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM
@@ -988,248 +1099,6 @@ Set-StrictMode -Version 2
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
 $SaveEAPreference = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
-
-If($Null -eq $MSWord)
-{
-	$MSWord = $False
-}
-If($Null -eq $PDF)
-{
-	$PDF = $False
-}
-If($Null -eq $Text)
-{
-	$Text = $False
-}
-If($Null -eq $HTML)
-{
-	$HTML = $False
-}
-If($Null -eq $MachineCatalogs)
-{
-	$MachineCatalogs = $False
-}
-If($Null -eq $AppDisks)
-{
-	$AppDisks = $False
-}
-If($Null -eq $DeliveryGroups)
-{
-	$DeliveryGroups = $False
-}
-If($Null -eq $DeliveryGroupsUtilization)
-{
-	$DeliveryGroupsUtilization = $False
-}
-If($Null -eq $Applications)
-{
-	$Applications = $False
-}
-If($Null -eq $Policies)
-{
-	$Policies = $False
-}
-If($Null -eq $NoPolicies)
-{
-	$NoPolicies = $False
-}
-If($Null -eq $NoADPolicies)
-{
-	$NoADPolicies = $False
-}
-If($Null -eq $Logging)
-{
-	$Logging = $False
-}
-If($Null -eq $Administrators)
-{
-	$Administrators = $False
-}
-If($Null -eq $Hosting)
-{
-	$Hosting = $False
-}
-If($Null -eq $StoreFront)
-{
-	$StoreFront = $False
-}
-If($Null -eq $StartDate)
-{
-	$StartDate = ((Get-Date -displayhint date).AddDays(-7))
-}
-If($Null -eq $EndDate)
-{
-	$EndDate = ((Get-Date -displayhint date))
-}
-If($Null -eq $AddDateTime)
-{
-	$AddDateTime = $False
-}
-If($Null -eq $Hardware)
-{
-	$Hardware = $False
-}
-If($Null -eq $AdminAddress)
-{
-	$AdminAddress = "LocalHost"
-}
-If($Null -eq $Section)
-{
-	$Section = "All"
-}
-If($Null -eq $Folder)
-{
-	$Folder = ""
-}
-If($Null -eq $SmtpServer)
-{
-	$SmtpServer = ""
-}
-If($Null -eq $SmtpPort)
-{
-	$SmtpPort = 25
-}
-If($Null -eq $UseSSL)
-{
-	$UseSSL = $False
-}
-If($Null -eq $From)
-{
-	$From = ""
-}
-If($Null -eq $To)
-{
-	$To = ""
-}
-If($Null -eq $Dev)
-{
-	$Dev = $False
-}
-If($Null -eq $ScriptInfo)
-{
-	$ScriptInfo = $False
-}
-
-If(!(Test-Path Variable:MSWord))
-{
-	$MSWord = $False
-}
-If(!(Test-Path Variable:PDF))
-{
-	$PDF = $False
-}
-If(!(Test-Path Variable:Text))
-{
-	$Text = $False
-}
-If(!(Test-Path Variable:HTML))
-{
-	$HTML = $False
-}
-If(!(Test-Path Variable:MachineCatalogs))
-{
-	$MachineCatalogs = $False
-}
-If(!(Test-Path Variable:AppDisks))
-{
-	$AppDisks = $False
-}
-If(!(Test-Path Variable:DeliveryGroups))
-{
-	$DeliveryGroups = $False
-}
-If(!(Test-Path Variable:DeliveryGroupsUtilization))
-{
-	$DeliveryGroupsUtilization = $False
-}
-If(!(Test-Path Variable:Applications))
-{
-	$Applications = $False
-}
-If(!(Test-Path Variable:Policies))
-{
-	$Policies = $False
-}
-If(!(Test-Path Variable:NoPolicies))
-{
-	$NoPolicies = $False
-}
-If(!(Test-Path Variable:NoADPolicies))
-{
-	$NoADPolicies = $False
-}
-If(!(Test-Path Variable:Logging))
-{
-	$Logging = $False
-}
-If(!(Test-Path Variable:Administrators))
-{
-	$Administrators = $False
-}
-If(!(Test-Path Variable:Hosting))
-{
-	$Hosting = $False
-}
-If(!(Test-Path Variable:StoreFront))
-{
-	$StoreFront = $False
-}
-If(!(Test-Path Variable:StartDate))
-{
-	$StartDate = ((Get-Date -displayhint date).AddDays(-7))
-}
-If(!(Test-Path Variable:EndDate))
-{
-	$EndDate = ((Get-Date -displayhint date))
-}
-If(!(Test-Path Variable:AddDateTime))
-{
-	$AddDateTime = $False
-}
-If(!(Test-Path Variable:Hardware))
-{
-	$Hardware = $False
-}
-If(!(Test-Path Variable:AdminAddress))
-{
-	$AdminAddress = "LocalHost"
-}
-If(!(Test-Path Variable:Section))
-{
-	$Section = "All"
-}
-If(!(Test-Path Variable:Folder))
-{
-	$Folder = ""
-}
-If(!(Test-Path Variable:SmtpServer))
-{
-	$SmtpServer = ""
-}
-If(!(Test-Path Variable:SmtpPort))
-{
-	$SmtpPort = 25
-}
-If(!(Test-Path Variable:UseSSL))
-{
-	$UseSSL = $False
-}
-If(!(Test-Path Variable:From))
-{
-	$From = ""
-}
-If(!(Test-Path Variable:To))
-{
-	$To = ""
-}
-If(!(Test-Path Variable:Dev))
-{
-	$Dev = $False
-}
-If(!(Test-Path Variable:ScriptInfo))
-{
-	$ScriptInfo = $False
-}
 
 If($Dev)
 {
@@ -3292,21 +3161,44 @@ Function ValidateCompanyName
 	}
 }
 
-Function _SetDocumentProperty 
-{
-	#jeff hicks
-	Param([object]$Properties,[string]$Name,[string]$Value)
-	#get the property object
-	$prop = $properties | ForEach { 
-		$propname=$_.GetType().InvokeMember("Name","GetProperty",$Null,$_,$Null)
-		If($propname -eq $Name) 
-		{
-			Return $_
-		}
-	} #ForEach
-
-	#set the value
-	$Prop.GetType().InvokeMember("Value","SetProperty",$Null,$prop,$Value)
+Function Set-DocumentProperty {
+    <#
+	.SYNOPSIS
+	Function to set the Title Page document properties in MS Word
+	.DESCRIPTION
+	Long description
+	.PARAMETER Document
+	Current Document Object
+	.PARAMETER DocProperty
+	Parameter description
+	.PARAMETER Value
+	Parameter description
+	.EXAMPLE
+	Set-DocumentProperty -Document $Script:Doc -DocProperty Title -Value 'MyTitle'
+	.EXAMPLE
+	Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value 'MyCompany'
+	.EXAMPLE
+	Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value 'Jim Moyle'
+	.EXAMPLE
+	Set-DocumentProperty -Document $Script:Doc -DocProperty Subject -Value 'MySubjectTitle'
+	.NOTES
+	Function Created by Jim Moyle June 2017
+	Twitter : @JimMoyle
+	#>
+    param (
+        [object]$Document,
+        [String]$DocProperty,
+        [string]$Value
+    )
+    try {
+        $binding = "System.Reflection.BindingFlags" -as [type]
+        $builtInProperties = $Document.BuiltInDocumentProperties
+        $property = [System.__ComObject].invokemember("item", $binding::GetProperty, $null, $BuiltinProperties, $DocProperty)
+        [System.__ComObject].invokemember("value", $binding::SetProperty, $null, $property, $Value)
+    }
+    catch {
+        Write-Warning "Failed to set $DocProperty to $Value"
+    }
 }
 
 Function FindWordDocumentEnd
@@ -3669,24 +3561,24 @@ Function SetupWord
 Function UpdateDocumentProperties
 {
 	Param([string]$AbstractTitle, [string]$SubjectTitle)
+	#updated 8-Jun-2017 with additional cover page fields
 	#Update document properties
 	If($MSWORD -or $PDF)
 	{
 		If($Script:CoverPagesExist)
 		{
 			Write-Verbose "$(Get-Date): Set Cover Page Properties"
-			_SetDocumentProperty $Script:Doc.BuiltInDocumentProperties "Company" $Script:CoName
-			_SetDocumentProperty $Script:Doc.BuiltInDocumentProperties "Title" $Script:Title
-			_SetDocumentProperty $Script:Doc.BuiltInDocumentProperties "Author" $username
-
-			_SetDocumentProperty $Script:Doc.BuiltInDocumentProperties "Subject" $SubjectTitle
+			#8-Jun-2017 put these 4 items in alpha order
+            Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value $UserName
+            Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value $Script:CoName
+            Set-DocumentProperty -Document $Script:Doc -DocProperty Subject -Value $SubjectTitle
+            Set-DocumentProperty -Document $Script:Doc -DocProperty Title -Value $Script:title
 
 			#Get the Coverpage XML part
 			$cp = $Script:Doc.CustomXMLParts | Where {$_.NamespaceURI -match "coverPageProps$"}
 
 			#get the abstract XML part
 			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "Abstract"}
-
 			#set the text
 			If([String]::IsNullOrEmpty($Script:CoName))
 			{
@@ -3694,9 +3586,32 @@ Function UpdateDocumentProperties
 			}
 			Else
 			{
-				[string]$abstract = "$($AbstractTitle) for $Script:CoName"
+				[string]$abstract = "$($AbstractTitle) for $($Script:CoName)"
 			}
+			$ab.Text = $abstract
 
+			#added 8-Jun-2017
+			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyAddress"}
+			#set the text
+			[string]$abstract = $CompanyAddress
+			$ab.Text = $abstract
+
+			#added 8-Jun-2017
+			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyEmail"}
+			#set the text
+			[string]$abstract = $CompanyEmail
+			$ab.Text = $abstract
+
+			#added 8-Jun-2017
+			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyFax"}
+			#set the text
+			[string]$abstract = $CompanyFax
+			$ab.Text = $abstract
+
+			#added 8-Jun-2017
+			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyPhone"}
+			#set the text
+			[string]$abstract = $CompanyPhone
 			$ab.Text = $abstract
 
 			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "PublishDate"}
@@ -4928,8 +4843,8 @@ Function Check-LoadedModule
 	#was manually loaded from a non Default folder
 	#$ModuleFound = (!$LoadedModules -like "*$ModuleName*")
 	
-	[bool]$ModuleFound = ($LoadedModules -like "*$ModuleName*")
-	If(!$ModuleFound) 
+	[string]$ModuleFound = ($LoadedModules -like "*$ModuleName*")
+	If($ModuleFound -ne $ModuleName) 
 	{
 		$module = Import-Module -Name $ModuleName -PassThru -EA 0 4>$Null
 		If($module -and $?)
@@ -5277,6 +5192,10 @@ Function ShowScriptOptions
 	Write-Verbose "$(Get-Date): Administrators  : $($Administrators)"
 	Write-Verbose "$(Get-Date): Applications    : $($Applications)"
 	Write-Verbose "$(Get-Date): Company Name    : $($Script:CoName)"
+	Write-Verbose "$(Get-Date): Company Address : $($CompanyAddress)"
+	Write-Verbose "$(Get-Date): Company Email   : $($CompanyEmail)"
+	Write-Verbose "$(Get-Date): Company Fax     : $($CompanyFax)"
+	Write-Verbose "$(Get-Date): Company Phone   : $($CompanyPhone)"
 	Write-Verbose "$(Get-Date): Cover Page      : $($CoverPage)"
 	Write-Verbose "$(Get-Date): DeliveryGroups  : $($DeliveryGroups)"
 	If($Dev)
@@ -9370,6 +9289,28 @@ Function OutputDeliveryGroupDetails
 	{
 		$CanRestrictToTags = $False
 	}
+	
+	#added for 7.14
+	If((Get-BrokerServiceAddedCapability @XDParams1) -contains "MultiTypeLicensing")
+	{
+		If($Null -eq $Group.LicenseModel)
+		{
+			$LicenseModel = "Site Default"
+		}
+		Else
+		{
+			$LicenseModel = $Group.LicenseModel
+		}
+		
+		If($Null -eq $Group.ProductCode)
+		{
+			$ProductCode = "Site Default"
+		}
+		Else
+		{
+			$ProductCode = $Group.ProductCode
+		}
+	}
 
 	$DesktopSettings = $Null
 	If($xDeliveryType -ne "Applications")
@@ -10017,6 +9958,12 @@ Function OutputDeliveryGroupDetails
 			}
 		}
 
+		If((Get-BrokerServiceAddedCapability @XDParams1) -contains "MultiTypeLicensing")
+		{
+			$ScriptInformation += @{Data = "License model"; Value = $LicenseModel; }
+			$ScriptInformation += @{Data = "Product code"; Value = $ProductCode; }
+		}
+
 		If($PwrMgmt1)
 		{
 			$ScriptInformation += @{Data = "During peak hours, when disconnected $($Group.PeakDisconnectTimeout) mins"; Value = $xPeakDisconnectAction; }
@@ -10422,11 +10369,17 @@ Function OutputDeliveryGroupDetails
 			}
 		}
 		
+		If((Get-BrokerServiceAddedCapability @XDParams1) -contains "MultiTypeLicensing")
+		{
+			Line 1 "License model`t`t`t`t`t: " $LicenseModel
+			Line 1 "Product code`t`t`t`t`t: " $ProductCode
+		}
+
 		If($PwrMgmt1)
 		{
-			Line 1 "During peak hours, when disconnected $($Group.PeakDisconnectTimeout) mins`t: " $xPeakDisconnectAction
+			Line 1 "During peak hours, when disconnected $($Group.PeakDisconnectTimeout) mins`t`t: " $xPeakDisconnectAction
 			Line 1 "During peak extended hours, when disconnected $($Group.PeakExtendedDisconnectTimeout) mins`t: " $xPeakExtendedDisconnectAction
-			Line 1 "During off-peak hours, when disconnected $($Group.OffPeakDisconnectTimeout) mins: " $xOffPeakDisconnectAction
+			Line 1 "During off-peak hours, when disconnected $($Group.OffPeakDisconnectTimeout) mins`t`t: " $xOffPeakDisconnectAction
 			Line 1 "During off-peak extended hours, when disconnected $($Group.OffPeakExtendedDisconnectTimeout) mins: " $xOffPeakExtendedDisconnectAction
 		}
 		If($PwrMgmt2)
@@ -10475,9 +10428,9 @@ Function OutputDeliveryGroupDetails
 				Line 7 "  "  "<none>"
 			}
 
-			Line 1 "During peak hours, when disconnected $($Group.PeakDisconnectTimeout) mins`t: " $xPeakDisconnectAction
+			Line 1 "During peak hours, when disconnected $($Group.PeakDisconnectTimeout) mins`t`t: " $xPeakDisconnectAction
 			Line 1 "During peak extended hours, when disconnected $($Group.PeakExtendedDisconnectTimeout) mins`t: " $xPeakExtendedDisconnectAction
-			Line 1 "During peak hours, when logged off $($Group.PeakLogOffTimeout) mins`t: " $xPeakLogOffAction
+			Line 1 "During peak hours, when logged off $($Group.PeakLogOffTimeout) mins`t`t: " $xPeakLogOffAction
 			Line 1 "During off-peak hours, when disconnected $($Group.OffPeakDisconnectTimeout) mins`t: " $xOffPeakDisconnectAction
 			Line 1 "During off-peak extended hours, when disconnected $($Group.OffPeakExtendedDisconnectTimeout) mins`t: " $xOffPeakExtendedDisconnectAction
 			Line 1 "During off-peak hours, when logged off $($Group.OffPeakLogOffTimeout) mins`t: " $xOffPeakLogOffAction
@@ -10578,12 +10531,12 @@ Function OutputDeliveryGroupDetails
 			Line 1 "During off-peak extended hours, when disconnected $($Group.OffPeakExtendedDisconnectTimeout) mins: " $xOffPeakExtendedDisconnectAction
 		}
 
-		Line 1 "Automatic power on for assigned`t`t`t: " $xAutoPowerOnForAssigned
-		Line 1 "Automatic power on for assigned during peak`t: " $xAutoPowerOnForAssignedDuringPeak
+		Line 1 "Automatic power on for assigned`t`t`t`t: " $xAutoPowerOnForAssigned
+		Line 1 "Automatic power on for assigned during peak`t`t: " $xAutoPowerOnForAssignedDuringPeak
 		
-		Line 1 "All connections not through NetScaler Gateway`t: " $xAllConnections
-		Line 1 "Connections through NetScaler Gateway`t`t: " $xNSConnection
-		Line 1 "Connections meeting any of the following filters: " $xAGFilters[0]
+		Line 1 "All connections not through NetScaler Gateway`t`t: " $xAllConnections
+		Line 1 "Connections through NetScaler Gateway`t`t`t: " $xNSConnection
+		Line 1 "Connections meeting any of the following filters`t: " $xAGFilters[0]
 		$cnt = -1
 		ForEach($tmp in $xAGFilters)
 		{
@@ -10810,6 +10763,12 @@ Function OutputDeliveryGroupDetails
 			{
 				$rowdata += @(,('Restart machines automatically',($htmlsilver -bor $htmlbold),"No",$htmlwhite))
 			}
+		}
+		
+		If((Get-BrokerServiceAddedCapability @XDParams1) -contains "MultiTypeLicensing")
+		{
+			$rowdata += @(,('License model',($htmlsilver -bor $htmlbold),$LicenseModel,$htmlwhite))
+			$rowdata += @(,('Product code',($htmlsilver -bor $htmlbold),$ProductCode,$htmlwhite))
 		}
 		
 		If($PwrMgmt1)
@@ -13295,6 +13254,7 @@ Function ProcessCitrixPolicies
 					ForEach($Filter in $Filters)
 					{
 						$tmp = ""
+						#5-May-2017 add back the WorkerGroup filter for xenapp 6.x
 						Switch($filter.FilterType)
 						{
 							"AccessControl"  {$tmp = "Access Control"; Break}
@@ -13306,6 +13266,7 @@ Function ProcessCitrixPolicies
 							"DesktopTag"     {$tmp = "Tag"; Break}
 							"OU"             {$tmp = "Organizational Unit (OU)"; Break}
 							"User"           {$tmp = "User or group"; Break}
+							"WorkerGroup"    {$tmp = "Worker Group"; Break}
 							Default {$tmp = "Policy Filter Type could not be determined: $($filter.FilterType)"; Break}
 						}
 						
@@ -13852,6 +13813,28 @@ Function ProcessCitrixPolicies
 					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA"
+					If((validStateProp $Setting ApplicationLaunchWaitTimeout State ) -and ($Setting.ApplicationLaunchWaitTimeout.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Application Launch Wait Timeout (milliseconds)"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ApplicationLaunchWaitTimeout.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ApplicationLaunchWaitTimeout.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ApplicationLaunchWaitTimeout.Value
+						}
+					}
 					If((validStateProp $Setting ClipboardRedirection State ) -and ($Setting.ClipboardRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Client clipboard redirection"
@@ -14120,6 +14103,28 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.NonPublishedProgramLaunching.Value 
+						}
+					}
+					If((validStateProp $Setting LogoffCheckerStartupDelay State ) -and ($Setting.LogoffCheckerStartupDelay.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Logoff Checker Startup Delay"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.LogoffCheckerStartupDelay.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.LogoffCheckerStartupDelay.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.LogoffCheckerStartupDelay.Value 
 						}
 					}
 					If((validStateProp $Setting PrimarySelectionUpdateMode State ) -and ($Setting.PrimarySelectionUpdateMode.State -ne "NotConfigured"))
@@ -23497,12 +23502,114 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.PSEnabled.State 
 						}
 					}
+					If((validStateProp $Setting StreamingExclusionList State ) -and ($Setting.StreamingExclusionList.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Streamed user profiles\Profile Streaming Exclusion list - directories"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.StreamingExclusionList.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.StreamingExclusionList.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.StreamingExclusionList.State 
+						}
+					}
+					If((validStateProp $Setting StreamingExclusionList_Part State ) -and ($Setting.StreamingExclusionList_Part.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Streamed user profiles\Profile Streaming Exclusion list - directories"
+						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
+						{
+							$tmpArray = $Setting.StreamingExclusionList_Part.Values.Split(",")
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $tmpArray)
+							{
+								$cnt++
+								$tmp = "$($Thing)"
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
+								}
+								Else
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+								}
+							}
+							$tmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.StreamingExclusionList_Part.State;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.StreamingExclusionList_Part.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.StreamingExclusionList_Part.State 
+							}
+						}
+					}
 					If((validStateProp $Setting PSUserGroups_Part State ) -and ($Setting.PSUserGroups_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Streamed user profiles\Streamed user profile groups"
 						If($Setting.PSUserGroups_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.PSUserGroups_Part.Values
+							$tmpArray = $Setting.PSUserGroups_Part.Values.Split(",")
 							$tmp = ""
 							$cnt = 0
 							ForEach($Thing in $tmpArray)
@@ -23883,6 +23990,59 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Monitoring"
+					If((validStateProp $Setting SelectedFailureLevel State ) -and ($Setting.SelectedFailureLevel.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable monitoring of application failures"
+						$tmp = ""
+						Switch ($Setting.SelectedFailureLevel.Value)
+						{
+							"None"	{$tmp = "None"; Break}
+							"Both"	{$tmp = "Both application errors and faults"; Break}
+							"Fault"	{$tmp = "Application faults only"; Break}
+							"Error"	{$tmp = "Application errors only"; Break}
+							Default	{$tmp = "Enable monitoring of application failures could not be determined: $($Setting.SelectedFailureLevel.Value)"; Break}
+						}
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $tmp;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp
+						}
+					}
+					If((validStateProp $Setting EnableWorkstationVDAFaultMonitoring State ) -and ($Setting.EnableWorkstationVDAFaultMonitoring.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable monitoring of application failures on Desktop OS VDAs"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.EnableWorkstationVDAFaultMonitoring.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.EnableWorkstationVDAFaultMonitoring.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.EnableWorkstationVDAFaultMonitoring.State 
+						}
+					}
 					If((validStateProp $Setting EnableProcessMonitoring State ) -and ($Setting.EnableProcessMonitoring.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable process monitoring"
@@ -23927,6 +24087,86 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.EnableResourceMonitoring.State 
 						}
 					}
+					If((validStateProp $Setting AppFailureExclusionList State ) -and ($Setting.AppFailureExclusionList.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\List of applications excluded from failure monitoring"
+						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
+						{
+							$tmpArray = $Setting.AppFailureExclusionList.Values.Split(",")
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $tmpArray)
+							{
+								$cnt++
+								$tmp = "$($Thing)"
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
+								}
+								Else
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+								}
+							}
+							$tmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.AppFailureExclusionList.State;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.AppFailureExclusionList.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.AppFailureExclusionList.State 
+							}
+						}
+					}	
 					If((validStateProp $Setting OnlyUseIPv6ControllerRegistration State ) -and ($Setting.OnlyUseIPv6ControllerRegistration.State -ne "NotConfigured"))
 					{
 						#AD specific setting
@@ -29199,71 +29439,75 @@ Function ProcessScriptEnd
 	{
 		$SIFile = "$($pwd.Path)\XAXDV2InventoryScriptInfo_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 		Out-File -FilePath $SIFile -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Add DateTime   : $($AddDateTime)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "AdminAddress   : $($AdminAddress)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Administrators : $($Administrators)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Applications   : $($Applications)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Add DateTime    : $($AddDateTime)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "AdminAddress    : $($AdminAddress)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Administrators  : $($Administrators)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Applications    : $($Applications)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Company Name   : $($Script:CoName)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Cover Page     : $($CoverPage)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Company Name    : $($Script:CoName)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Address : $($CompanyAddress)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Email   : $($CompanyEmail)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Fax     : $($CompanyFax)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Phone   : $($CompanyPhone)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Cover Page      : $($CoverPage)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "DeliveryGroups : $($DeliveryGroups)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Dev            : $($Dev)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "DeliveryGroups  : $($DeliveryGroups)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Dev             : $($Dev)" 4>$Null
 		If($Dev)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "DevErrorFile   : $($Script:DevErrorFile)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "DevErrorFile    : $($Script:DevErrorFile)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "DGUtilization  : $($DeliveryGroupsUtilization)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Filename1      : $($Script:FileName1)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "DGUtilization   : $($DeliveryGroupsUtilization)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Filename1       : $($Script:FileName1)" 4>$Null
 		If($PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Filename2      : $($Script:FileName2)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Filename2       : $($Script:FileName2)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "Folder         : $($Folder)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "From           : $($From)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Hosting        : $($Hosting)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "HW Inventory   : $($Hardware)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Logging        : $($Logging)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Folder          : $($Folder)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "From            : $($From)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Hosting         : $($Hosting)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "HW Inventory    : $($Hardware)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Logging         : $($Logging)" 4>$Null
 		If($Logging)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "   Start Date   : $($StartDate)" 4>$Null
-			Out-File -FilePath $SIFile -Append -InputObject "   End Date     : $($EndDate)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "   Start Date    : $($StartDate)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "   End Date      : $($EndDate)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "MachineCatalogs: $($MachineCatalogs)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "NoADPolicies   : $($NoADPolicies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "NoPolicies     : $($NoPolicies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Policies       : $($Policies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As HTML   : $($HTML)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As PDF    : $($PDF)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As TEXT   : $($TEXT)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As WORD   : $($MSWORD)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Script Info    : $($ScriptInfo)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Section        : $($Section)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Site Name      : $($XDSiteName)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Smtp Port      : $($SmtpPort)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Smtp Server    : $($SmtpServer)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Title          : $($Script:Title)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "To             : $($To)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Use SSL        : $($UseSSL)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "MachineCatalogs : $($MachineCatalogs)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "NoADPolicies    : $($NoADPolicies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "NoPolicies      : $($NoPolicies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Policies        : $($Policies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As HTML    : $($HTML)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As PDF     : $($PDF)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As TEXT    : $($TEXT)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As WORD    : $($MSWORD)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Script Info     : $($ScriptInfo)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Section         : $($Section)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Site Name       : $($XDSiteName)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Smtp Port       : $($SmtpPort)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Smtp Server     : $($SmtpServer)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Title           : $($Script:Title)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "To              : $($To)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Use SSL         : $($UseSSL)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "User Name      : $($UserName)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "User Name       : $($UserName)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "XA/XD Version  : $($Script:XDSiteVersion)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "XA/XD Version   : $($Script:XDSiteVersion)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "OS Detected    : $($Script:RunningOS)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PoSH version   : $($Host.Version)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PSCulture      : $($PSCulture)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PSUICulture    : $($PSUICulture)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "OS Detected     : $($Script:RunningOS)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PoSH version    : $($Host.Version)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PSCulture       : $($PSCulture)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PSUICulture     : $($PSUICulture)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Word language  : $($Script:WordLanguageValue)" 4>$Null
-			Out-File -FilePath $SIFile -Append -InputObject "Word version   : $($Script:WordProduct)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Word language   : $($Script:WordLanguageValue)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Word version    : $($Script:WordProduct)" 4>$Null
 		}
 		Out-File -FilePath $SIFile -Append -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Script start   : $($Script:StartTime)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Elapsed time   : $($Str)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Script start    : $($Script:StartTime)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Elapsed time    : $($Str)" 4>$Null
 	}
 
 	$ErrorActionPreference = $SaveEAPreference
@@ -29382,4 +29626,4 @@ UpdateDocumentProperties $AbstractTitle $SubjectTitle
 ProcessDocumentOutput
 
 ProcessScriptEnd
-#endregion
+#endregionn

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -936,7 +936,7 @@
 	NAME: XD7_Inventory_V2.ps1
 	VERSION: 2.05
 	AUTHOR: Carl Webster
-	LASTEDIT: June 18, 2017
+	LASTEDIT: June 24, 2017
 #>
 
 #endregion
@@ -1143,6 +1143,7 @@ Param(
 #		There are 315 registry keys and values that are checked and listed
 #		Updated Function OutputControllers
 #	Added Controller version information to the Controllers section
+#	Added "Database Size" to the Datastores output
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
@@ -1183,9 +1184,10 @@ Param(
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function ProcessScriptEnd for the new Cover Page properties
-#	Updated Function ShowScriptOptions for the new Cover Page properties
-#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated Function OutputDatastores to add database size
+#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
+#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
 #	Updated help text
 #	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for
 #	
@@ -26035,11 +26037,11 @@ Function OutputConfigLogPreferences
 					$Pair = $csitem.split('=').trimstart()
 					Switch ($Pair[0])
 					{
-						"Server"					{$LogSQLServerPrincipalName = $Pair[1]}
-						"Failover Partner"			{$LogSQLServerMirrorName = $Pair[1]}
-						"MultiSubnetFailover"		{$LogSQLServerMirrorName = ""}
-						"Database"					{$LogDatabaseName = $Pair[1]}
-						{$Pair[0] -match "Initial"}	{$LogDatabaseName = $Pair[1]}
+						"Server"					{$LogSQLServerPrincipalName = $Pair[1]; Break}
+						"Failover Partner"			{$LogSQLServerMirrorName = $Pair[1]; Break}
+						"MultiSubnetFailover"		{$LogSQLServerMirrorName = ""; Break}
+						"Database"					{$LogDatabaseName = $Pair[1]; Break}
+						"Initial Catalog"			{$LogDatabaseName = $Pair[1]; Break}
 					}
 				}
 			}
@@ -26401,11 +26403,14 @@ Function OutputDatastores
 
 	#line starts with server=SQLServerName;
 	#only need what is between the = and ;
+	
+	#24-Jun-2017 add Database Size to the output
 	Write-Verbose "$(Get-Date): `tRetrieving database connection data"
 	Write-Verbose "$(Get-Date): `t`tConfiguration database"
 	$ConfigSQLServerPrincipalName = ""
 	$ConfigSQLServerMirrorName = ""
 	$ConfigDatabaseName = ""
+	[string]$ConfigDBSize = "Unable to determine"
 	$ConfigDB = Get-ConfigDBConnection @XDParams1
 
 	If($? -and ($Null -ne $ConfigDB))
@@ -26417,13 +26422,17 @@ Function OutputDatastores
 			$Pair = $csitem.split('=').trimstart()
 			Switch ($Pair[0])
 			{
-				"Server"					{$ConfigSQLServerPrincipalName = $Pair[1]}
-				"Failover Partner"			{$ConfigSQLServerMirrorName = $Pair[1]}
-				"MultiSubnetFailover"		{$ConfigSQLServerMirrorName = ""}
-				"Database"					{$ConfigDatabaseName = $Pair[1]}
-				{$Pair[0] -match "Initial"}	{$ConfigDatabaseName = $Pair[1]}
+				"Server"					{$ConfigSQLServerPrincipalName = $Pair[1]; Break}
+				"Failover Partner"			{$ConfigSQLServerMirrorName = $Pair[1]; Break}
+				"MultiSubnetFailover"		{$ConfigSQLServerMirrorName = ""; Break}
+				"Database"					{$ConfigDatabaseName = $Pair[1]; Break}
+				"Initial Catalog"			{$ConfigDatabaseName = $Pair[1]; Break}
 			}
 		}
+		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
+		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+		$db = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
+		$ConfigDBSize = "{0:F2} MB" -f $db.size
 	}
 	Else
 	{
@@ -26434,6 +26443,7 @@ Function OutputDatastores
 	$LogSQLServerPrincipalName = ""
 	$LogSQLServerMirrorName = ""
 	$LogDatabaseName = ""
+	[string]$LogDBSize = "Unable to determine"
 	$LogDBs = Get-LogDataStore @XDParams1
 
 	If($? -and ($Null -ne $LogDBs))
@@ -26449,15 +26459,19 @@ Function OutputDatastores
 					$Pair = $csitem.split('=').trimstart()
 					Switch ($Pair[0])
 					{
-						"Server"					{$LogSQLServerPrincipalName = $Pair[1]}
-						"Failover Partner"			{$LogSQLServerMirrorName = $Pair[1]}
-						"MultiSubnetFailover"		{$LogSQLServerMirrorName = ""}
-						"Database"					{$LogDatabaseName = $Pair[1]}
-						{$Pair[0] -match "Initial"}	{$LogDatabaseName = $Pair[1]}
+						"Server"					{$LogSQLServerPrincipalName = $Pair[1]; Break}
+						"Failover Partner"			{$LogSQLServerMirrorName = $Pair[1]; Break}
+						"MultiSubnetFailover"		{$LogSQLServerMirrorName = ""; Break}
+						"Database"					{$LogDatabaseName = $Pair[1]; Break}
+						"Initial Catalog"			{$LogDatabaseName = $Pair[1]; Break}
 					}
 				}
 			}
 		}
+		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
+		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+		$db = $SQLsrv.Databases.Item("$($LogDatabaseName)")
+		$LogDBSize = "{0:F2} MB" -f $db.size
 	}
 	Else
 	{
@@ -26468,6 +26482,7 @@ Function OutputDatastores
 	$MonitorSQLServerPrincipalName = ""
 	$MonitorSQLServerMirrorName = ""
 	$MonitorDatabaseName = ""
+	[string]$MonitorDBSize = "Unable to determine"
 	$MonitorCollectHotfix = "Disabled"
 	$MonitorDataCollection = "Disabled"
 	$MonitorDetailedSQL = "Disabled"
@@ -26487,15 +26502,19 @@ Function OutputDatastores
 					$Pair = $csitem.split('=').trimstart()
 					Switch ($Pair[0])
 					{
-						"Server"					{$MonitorSQLServerPrincipalName = $Pair[1]}
-						"Failover Partner"			{$MonitorSQLServerMirrorName = $Pair[1]}
-						"MultiSubnetFailover"		{$MonitorSQLServerMirrorName = ""}
-						"Database"					{$MonitorDatabaseName = $Pair[1]}
-						{$Pair[0] -match "Initial"}	{$MonitorDatabaseName = $Pair[1]}
+						"Server"					{$MonitorSQLServerPrincipalName = $Pair[1]; Break}
+						"Failover Partner"			{$MonitorSQLServerMirrorName = $Pair[1]; Break}
+						"MultiSubnetFailover"		{$MonitorSQLServerMirrorName = ""; Break}
+						"Database"					{$MonitorDatabaseName = $Pair[1]; Break}
+						"Initial Catalog"			{$MonitorDatabaseName = $Pair[1]; Break}
 					}
 				}
 			}
 		}
+		$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerPrincipalName)")
+		$db = New-Object Microsoft.SqlServer.Management.Smo.Database
+		$db = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
+		$MonitorDBSize = "{0:F2} MB" -f $db.size
 		
 		$MonitorConfig = $Null
 		$MonitorConfig = Get-MonitorConfiguration @XDParams1
@@ -26545,6 +26564,7 @@ Function OutputDatastores
 		DatabaseName = $ConfigDatabaseName;
 		ServerAddress = $ConfigSQLServerPrincipalName;
 		MirrorServerAddress = $ConfigSQLServerMirrorName;
+		DBSize = $ConfigDBSize;
 		}
 		$DBsWordTable += $WordTableRowHash;
 
@@ -26553,6 +26573,7 @@ Function OutputDatastores
 		DatabaseName = $LogDatabaseName;
 		ServerAddress = $LogSQLServerPrincipalName;
 		MirrorServerAddress = $LogSQLServerMirrorName;
+		DBSize = $LogDBSize;
 		}
 		$DBsWordTable += $WordTableRowHash;
 
@@ -26561,12 +26582,13 @@ Function OutputDatastores
 		DatabaseName = $MonitorDatabaseName;
 		ServerAddress = $MonitorSQLServerPrincipalName;
 		MirrorServerAddress = $MonitorSQLServerMirrorName;
+		DBSize = $MonitorDBSize;
 		}
 		$DBsWordTable += $WordTableRowHash;
 
 		$Table = AddWordTable -Hashtable $DBsWordTable `
-		-Columns DataStore, DatabaseName, ServerAddress, MirrorServerAddress `
-		-Headers "Datastore", "Database Name", "Server Address", "Mirror Server Address" `
+		-Columns DataStore, DatabaseName, ServerAddress, MirrorServerAddress, DBSize `
+		-Headers "Datastore", "Database Name", "Server Address", "Mirror Server Address", "Database Size" `
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitContent;
 
@@ -26635,16 +26657,19 @@ Function OutputDatastores
 		Line 1 "Database Name`t`t: " $ConfigDatabaseName
 		Line 1 "Server Address`t`t: " $ConfigSQLServerPrincipalName
 		Line 1 "Mirror Server Address`t: " $ConfigSQLServerMirrorName
+		Line 1 "Database Size`t`t: " $ConfigDBSize
 		Line 0 ""
 		Line 1 "Datastore`t`t: Logging"
 		Line 1 "Database Name`t`t: " $LogDatabaseName
 		Line 1 "Server Address`t`t: " $LogSQLServerPrincipalName
 		Line 1 "Mirror Server Address`t: " $LogSQLServerMirrorName
+		Line 1 "Database Size`t`t: " $LogDBSize
 		Line 0 ""
 		Line 1 "Datastore`t`t: Monitoring"
 		Line 1 "Database Name`t`t: " $MonitorDatabaseName
 		Line 1 "Server Address`t`t: " $MonitorSQLServerPrincipalName
 		Line 1 "Mirror Server Address`t: " $MonitorSQLServerMirrorName
+		Line 1 "Database Size`t`t: " $MonitorDBSize
 		Line 0 ""
 		Line 1 "Monitoring Database Details"
 		Line 1 "Collect Hotfix Data`t`t: " $MonitorCollectHotfix
@@ -26674,25 +26699,29 @@ Function OutputDatastores
 		'Site',$htmlwhite,
 		$ConfigDatabaseName,$htmlwhite,
 		$ConfigSQLServerPrincipalName,$htmlwhite,
-		$ConfigSQLServerMirrorName,$htmlwhite))
+		$ConfigSQLServerMirrorName,$htmlwhite,
+		$ConfigDBSize))
 
 		$rowdata += @(,(
 		'Logging',$htmlwhite,
 		$LogDatabaseName,$htmlwhite,
 		$LogSQLServerPrincipalName,$htmlwhite,
-		$LogSQLServerMirrorName,$htmlwhite))
+		$LogSQLServerMirrorName,$htmlwhite,
+		$LogDBSize))
 
 		$rowdata += @(,(
 		'Monitoring',$htmlwhite,
 		$MonitorDatabaseName,$htmlwhite,
 		$MonitorSQLServerPrincipalName,$htmlwhite,
-		$MonitorSQLServerMirrorName,$htmlwhite))
+		$MonitorSQLServerMirrorName,$htmlwhite,
+		$MonitorDBSize))
 
 		$columnHeaders = @(
 		'Datastore',($htmlsilver -bor $htmlbold),
 		'Database Name',($htmlsilver -bor $htmlbold),
 		'Server Address',($htmlsilver -bor $htmlbold),
-		'Mirror Server Address',($htmlsilver -bor $htmlbold))
+		'Mirror Server Address',($htmlsilver -bor $htmlbold),
+		'Database Size',($htmlsilver -bor $htmlbold))
 
 		$msg = ""
 		FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders
@@ -31221,7 +31250,7 @@ Function ProcessScriptEnd
 			Out-File -FilePath $SIFile -Append -InputObject "   End Date        : $($EndDate)" 4>$Null
 		}
 		Out-File -FilePath $SIFile -Append -InputObject "MachineCatalogs    : $($MachineCatalogs)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "MaxDetail          : $($MaxDetail)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "MaxDetails         : $($MaxDetails)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "NoADPolicies       : $($NoADPolicies)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "NoPolicies         : $($NoPolicies)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "Policies           : $($Policies)" 4>$Null

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -936,7 +936,7 @@
 	NAME: XD7_Inventory_V2.ps1
 	VERSION: 2.05
 	AUTHOR: Carl Webster
-	LASTEDIT: June 16, 2017
+	LASTEDIT: June 18, 2017
 #>
 
 #endregion
@@ -1147,7 +1147,7 @@ Param(
 #		Company Phone
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
-#		This is the same as using the follwoing parameters:
+#		This is the same as using the following parameters:
 #			Administrators
 #			AppDisks
 #			Applications
@@ -1172,6 +1172,7 @@ Param(
 #	Added Version information to Controllers
 #	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fixed Function Check-LoadedModule
+#	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
@@ -3007,18 +3008,18 @@ Function GetCulture
 
 	Switch ($WordValue)
 	{
-		{$CatalanArray -contains $_} {$CultureCode = "ca-"}
-		{$ChineseArray -contains $_} {$CultureCode = "zh-"}
-		{$DanishArray -contains $_} {$CultureCode = "da-"}
-		{$DutchArray -contains $_} {$CultureCode = "nl-"}
-		{$EnglishArray -contains $_} {$CultureCode = "en-"}
-		{$FinnishArray -contains $_} {$CultureCode = "fi-"}
-		{$FrenchArray -contains $_} {$CultureCode = "fr-"}
-		{$GermanArray -contains $_} {$CultureCode = "de-"}
-		{$NorwegianArray -contains $_} {$CultureCode = "nb-"}
-		{$PortugueseArray -contains $_} {$CultureCode = "pt-"}
-		{$SpanishArray -contains $_} {$CultureCode = "es-"}
-		{$SwedishArray -contains $_} {$CultureCode = "sv-"}
+		{$CatalanArray -contains $_}	{$CultureCode = "ca-"}
+		{$ChineseArray -contains $_}	{$CultureCode = "zh-"}
+		{$DanishArray -contains $_}		{$CultureCode = "da-"}
+		{$DutchArray -contains $_}		{$CultureCode = "nl-"}
+		{$EnglishArray -contains $_}	{$CultureCode = "en-"}
+		{$FinnishArray -contains $_}	{$CultureCode = "fi-"}
+		{$FrenchArray -contains $_}		{$CultureCode = "fr-"}
+		{$GermanArray -contains $_}		{$CultureCode = "de-"}
+		{$NorwegianArray -contains $_}	{$CultureCode = "nb-"}
+		{$PortugueseArray -contains $_}	{$CultureCode = "pt-"}
+		{$SpanishArray -contains $_}	{$CultureCode = "es-"}
+		{$SwedishArray -contains $_}	{$CultureCode = "sv-"}
 		Default {$CultureCode = "en-"}
 	}
 	
@@ -13793,7 +13794,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t      " $tmp
 								}
 							}
 							$txt = ""
@@ -13898,7 +13899,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t" $tmp
 								}
 							}
 						}
@@ -14002,7 +14003,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t   " $tmp
 								}
 							}
 							$txt = ""
@@ -14402,7 +14403,7 @@ Function ProcessCitrixPolicies
 						{
 							$WordTableRowHash = @{
 							Text = $txt;
-							Value = $Setting.NonPublishedProgramLaunching.Value;
+							Value = $Setting.NonPublishedProgramLaunching.State;
 							}
 							$SettingsWordTable += $WordTableRowHash;
 						}
@@ -14410,11 +14411,11 @@ Function ProcessCitrixPolicies
 						{
 							$rowdata += @(,(
 							$txt,$htmlbold,
-							$Setting.NonPublishedProgramLaunching.Value,$htmlwhite))
+							$Setting.NonPublishedProgramLaunching.State,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							OutputPolicySetting $txt $Setting.NonPublishedProgramLaunching.Value 
+							OutputPolicySetting $txt $Setting.NonPublishedProgramLaunching.State
 						}
 					}
 					If((validStateProp $Setting LogoffCheckerStartupDelay State ) -and ($Setting.LogoffCheckerStartupDelay.State -ne "NotConfigured"))
@@ -14626,6 +14627,28 @@ Function ProcessCitrixPolicies
 					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Adobe Flash Delivery\Flash Redirection"
+					If((validStateProp $Setting FlashAcceleration State ) -and ($Setting.FlashAcceleration.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash acceleration"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.FlashAcceleration.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.FlashAcceleration.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.FlashAcceleration.State 
+						}
+					}
 					If((validStateProp $Setting FlashUrlColorList State ) -and ($Setting.FlashUrlColorList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash background color list"
@@ -14765,6 +14788,28 @@ Function ProcessCitrixPolicies
 						}
 						$tmp = $Null
 					}
+					If((validStateProp $Setting FlashEventLogging State ) -and ($Setting.FlashEventLogging.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash event logging"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.FlashEventLogging.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.FlashEventLogging.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.FlashEventLogging.State 
+						}
+					}
 					If((validStateProp $Setting FlashIntelligentFallback State ) -and ($Setting.FlashIntelligentFallback.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash intelligent fallback"
@@ -14897,26 +14942,26 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting FlashUrlCompatibilityList State ) -and ($Setting.FlashUrlCompatibilityList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash URL compatibility list"
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = "";
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							"",$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt
-						}
 						If(validStateProp $Setting FlashUrlCompatibilityList Values )
 						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = "";
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								"",$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt
+							}
 							$Values = $Setting.FlashUrlCompatibilityList.Values
 							$tmp = ""
 							ForEach($Value in $Values)
@@ -15015,7 +15060,7 @@ Function ProcessCitrixPolicies
 							If($MSWord -or $PDF)
 							{
 								$WordTableRowHash = @{
-								Text = "";
+								Text = $txt;
 								Value = $tmp;
 								}
 								$SettingsWordTable += $WordTableRowHash;
@@ -15023,12 +15068,12 @@ Function ProcessCitrixPolicies
 							ElseIf($HTML)
 							{
 								$rowdata += @(,(
-								"",$htmlbold,
+								$txt,$htmlbold,
 								$tmp,$htmlwhite))
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting $txt $tmp
 							}
 						}
 					}
@@ -15041,7 +15086,8 @@ Function ProcessCitrixPolicies
 							"Small"						{$tmp = "Only small content"; Break}
 							"SmallContentWRedirection"	{$tmp = "Only small content with a supported client"; Break}
 							"NoServerSide"				{$tmp = "No server side content"; Break}
-							Default {$tmp = "Flash video fallback prevention could not be determined: $($Setting.HDXFlashLoadManagement.Value)"; Break}
+							"Unconfigured"				{$tmp = "Not Configured"; Break}
+							Default 					{$tmp = "Flash video fallback prevention could not be determined: $($Setting.HDXFlashLoadManagement.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
@@ -15782,6 +15828,28 @@ Function ProcessCitrixPolicies
 					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Desktop UI"
+					If((validStateProp $Setting AeroRedirection State ) -and ($Setting.AeroRedirection.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Desktop UI\Aero Redirection"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.AeroRedirection.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.AeroRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.AeroRedirection.State 
+						}
+					}
 					If((validStateProp $Setting GraphicsQuality State ) -and ($Setting.GraphicsQuality.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Desktop UI\Desktop Composition graphics quality"
@@ -17149,10 +17217,11 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.VideoLoadManagement.Value)
 						{
-							"SFSR"	{$tmp = "Play all content"; Break}
-							"SFCR"	{$tmp = "Play all content only on client"; Break}
-							"CFCR"	{$tmp = "Play only client-accessible content on client"; Break}
-							Default	{$tmp = "Windows media fallback prevention could not be determined: $($Setting.VideoLoadManagement.Value)"; Break}
+							"SFSR"			{$tmp = "Play all content"; Break}
+							"SFCR"			{$tmp = "Play all content only on client"; Break}
+							"CFCR"			{$tmp = "Play only client-accessible content on client"; Break}
+							"UnConfigured"	{$tmp = "Not Configured"; Break}
+							Default			{$tmp = "Windows media fallback prevention could not be determined: $($Setting.VideoLoadManagement.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
@@ -17614,7 +17683,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting DefaultClientPrinter State ) -and ($Setting.DefaultClientPrinter.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Printing\Default printer"
+						$txt = "ICA\Printing\Default printer - Choose client's Default printer"
 						$tmp = ""
 						Switch ($Setting.DefaultClientPrinter.Value)
 						{
@@ -17659,25 +17728,29 @@ Function ProcessCitrixPolicies
 									$tmp1 = ""
 									$tmp2 = ""
 									$tmp3 = ""
+									
 									ForEach($Filter in $PrinterAssignment.Filters)
 									{
 										$Client += "$($Filter); "
 									}
-									If($PrinterAssignment.SpecificDefaultPrinter -eq "")
+									
+									Switch ($PrinterAssignment.DefaultPrinterOption)
 									{
-										$DefaultPrinter = "<Not set>"
+										"ClientDefault"		{$DefaultPrinter = "Client main printer"; Break}
+										"NotConfigured"		{$DefaultPrinter = "<Not set>"; Break}
+										"DoNotAdjust"		{$DefaultPrinter = "Do not adjust"; Break}
+										"SpecificPrinter"	{$DefaultPrinter = $PrinterAssignment.SpecificDefaultPrinter; Break}
+										Default				{$DefaultPrinter = "<Not set>"; Break}
 									}
-									Else
-									{
-										$DefaultPrinter = $PrinterAssignment.SpecificDefaultPrinter
-									}
+									
 									ForEach($SessionPrinter in $PrinterAssignment.SessionPrinters)
 									{
 										$SessionPrinters += $SessionPrinter
 									}
+									
 									$tmp1 = "Client Names/IP's: $($Client)"
-									$tmp2 = "Default Printer: $($DefaultPrinter)"
-									$tmp3 = "Session Printers: $($SessionPrinters)"
+									$tmp2 = "Default Printer  : $($DefaultPrinter)"
+									$tmp3 = "Session Printers : $($SessionPrinters)"
 									If($MSWord -or $PDF)
 									{
 										$WordTableRowHash = @{
@@ -17715,27 +17788,8 @@ Function ProcessCitrixPolicies
 									ElseIf($Text)
 									{
 										OutputPolicySetting $txt $tmp1
-										OutputPolicySetting "" $tmp2
-										OutputPolicySetting "" $tmp3
-									}
-									$tmp = " "
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
-									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
+										OutputPolicySetting "`t`t`t`t" $tmp2
+										OutputPolicySetting "`t`t`t`t" $tmp3
 									}
 									$tmp1 = $Null
 									$tmp2 = $Null
@@ -17799,26 +17853,26 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting SessionPrinters State ) -and ($Setting.SessionPrinters.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Session printers"
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = "";
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							"",$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt ""
-						}
 						If(validStateProp $Setting SessionPrinters Values )
 						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = "";
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								"",$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt ""
+							}
 							$valArray = $Setting.SessionPrinters.Values
 							$tmp = ""
 							ForEach($printer in $valArray)
@@ -17915,7 +17969,7 @@ Function ProcessCitrixPolicies
 							If($MSWord -or $PDF)
 							{
 								$WordTableRowHash = @{
-								Text = "";
+								Text = $txt;
 								Value = $tmp;
 								}
 								$SettingsWordTable += $WordTableRowHash;
@@ -17923,12 +17977,12 @@ Function ProcessCitrixPolicies
 							ElseIf($HTML)
 							{
 								$rowdata += @(,(
-								"",$htmlbold,
+								$txt,$htmlbold,
 								$tmp,$htmlwhite))
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting $txt $tmp
 							}
 						}
 					}
@@ -18158,9 +18212,9 @@ Function ProcessCitrixPolicies
 									}
 									ElseIf($Text)
 									{
-										OutputPolicySetting "" $tmp
+										OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 									}
-									$tmp = "Action: $($Action)"
+									$tmp = "Action     : $($Action)"
 									If($MSWord -or $PDF)
 									{
 										$WordTableRowHash = @{
@@ -18177,9 +18231,9 @@ Function ProcessCitrixPolicies
 									}
 									ElseIf($Text)
 									{
-										OutputPolicySetting "" $tmp
+										OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 									}
-									$tmp = "Settings: "
+									$tmp = "Settings   : "
 									If($MSWord -or $PDF)
 									{
 										$WordTableRowHash = @{
@@ -18196,7 +18250,7 @@ Function ProcessCitrixPolicies
 									}
 									ElseIf($Text)
 									{
-										OutputPolicySetting "" $tmp
+										OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 									}
 									If($Items.count -gt 2)
 									{
@@ -18224,7 +18278,7 @@ Function ProcessCitrixPolicies
 												}
 												ElseIf($Text)
 												{
-													OutputPolicySetting "" $tmp
+													OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 												}
 											}
 										}
@@ -18248,7 +18302,7 @@ Function ProcessCitrixPolicies
 										}
 										ElseIf($Text)
 										{
-											OutputPolicySetting "" $tmp
+											OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 										}
 									}
 
@@ -18271,7 +18325,7 @@ Function ProcessCitrixPolicies
 										}
 										ElseIf($Text)
 										{
-											OutputPolicySetting "" $tmp
+											OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 										}
 									}
 									$tmp = $Null
@@ -18284,7 +18338,7 @@ Function ProcessCitrixPolicies
 							If($MSWord -or $PDF)
 							{
 								$WordTableRowHash = @{
-								Text = "";
+								Text = $txt;
 								Value = $tmp;
 								}
 								$SettingsWordTable += $WordTableRowHash;
@@ -18292,12 +18346,12 @@ Function ProcessCitrixPolicies
 							ElseIf($HTML)
 							{
 								$rowdata += @(,(
-								"",$htmlbold,
+								$txt,$htmlbold,
 								$tmp,$htmlwhite))
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting $txt $tmp
 							}
 						}
 					}
@@ -18433,7 +18487,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t" $tmp
 								}
 							}
 						}
@@ -18787,8 +18841,8 @@ Function ProcessCitrixPolicies
 									Switch($TestSetting)
 									{
 										"StandardQuality"	{$TxtSetting = "Standard quality"; Break}
-										"BestQuality"	{$TxtSetting = "Best quality (lossless compression)"; Break}
-										"HighQuality"	{$TxtSetting = "High quality"; Break}
+										"BestQuality"		{$TxtSetting = "Best quality (lossless compression)"; Break}
+										"HighQuality"		{$TxtSetting = "High quality"; Break}
 										"ReducedQuality"	{$TxtSetting = "Reduced quality (maximum compression)"; Break}
 									}
 								}
@@ -18858,7 +18912,7 @@ Function ProcessCitrixPolicies
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting "`t`t`t`t`t`t`t`t`t" $tmp
 							}
 						}
 						$TmpArray = $Null
@@ -23073,7 +23127,7 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRSavedGames_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSavedGames_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
@@ -23149,7 +23203,7 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRSearches_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSearches_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
@@ -23225,7 +23279,7 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRStartMenu_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRStartMenu_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
@@ -24392,7 +24446,7 @@ Function ProcessCitrixPolicies
 										}
 										ElseIf($Text)
 										{
-											OutputPolicySetting "" $tmp
+											OutputPolicySetting "`t`t`t`t`t`t`t`t`t`t`t" $tmp
 										}
 									}
 								}
@@ -24597,16 +24651,17 @@ Function ProcessCitrixPolicies
 						$txt = ""
 						If(validStateProp $Setting StorefrontAccountsList Values )
 						{
+							$cnt = 0
 							$tmpArray = $Setting.StorefrontAccountsList.Values
 							ForEach($Thing in $TmpArray)
 							{
 								$cnt++
 								$xxx = """$($Thing)"""
 								[array]$tmp = $xxx.Split(";").replace('"','')
-								$tmp1 = "Name: $($tmp[0])"
-								$tmp2 = "URL: $($tmp[1])"
+								$tmp1 = "Name : $($tmp[0])"
+								$tmp2 = "URL  : $($tmp[1])"
 								$tmp3 = "State: $($tmp[2])"
-								$tmp4 = "Desc: $($tmp[3])"
+								$tmp4 = "Desc : $($tmp[3])"
 								If($MSWord -or $PDF)
 								{
 									$WordTableRowHash = @{
@@ -24653,29 +24708,34 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
+									$txt = "`t`t`t`t "
 									OutputPolicySetting $txt $tmp1
 									OutputPolicySetting $txt $tmp2
 									OutputPolicySetting $txt $tmp3
 									OutputPolicySetting $txt $tmp4
 								}
-								$tmp = " "
-								If($MSWord -or $PDF)
+								
+								If($cnt -gt 1)
 								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									$tmp = " "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									"",$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										"",$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 								$xxx = $Null
 								$tmp = $Null
@@ -24827,6 +24887,74 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
+					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\CPU Usage Monitoring"
+					If((validStateProp $Setting CPUUsageMonitoring_Enable State ) -and ($Setting.CPUUsageMonitoring_Enable.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\CPU Usage Monitoring\Enable Monitoring"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.CPUUsageMonitoring_Enable.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.CPUUsageMonitoring_Enable.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.CPUUsageMonitoring_Enable.State 
+						}
+					}
+					If((validStateProp $Setting CPUUsageMonitoring_Period State ) -and ($Setting.CPUUsageMonitoring_Period.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\CPU Usage Monitoring\Monitoring Period (seconds)"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.CPUUsageMonitoring_Period.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.CPUUsageMonitoring_Period.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.CPUUsageMonitoring_Period.Value 
+						}
+					}
+					If((validStateProp $Setting CPUUsageMonitoring_Threshold State ) -and ($Setting.CPUUsageMonitoring_Threshold.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\CPU Usage Monitoring\Threshold (percent)"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.CPUUsageMonitoring_Threshold.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.CPUUsageMonitoring_Threshold.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.CPUUsageMonitoring_Threshold.Value 
+						}
+					}
+
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\HDX3DPro"
 					If((validStateProp $Setting EnableLossless State ) -and ($Setting.EnableLossless.State -ne "NotConfigured"))
 					{
@@ -24877,6 +25005,74 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $tmp 
 						}
 						$tmp = $Null
+					}
+
+					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\ICA Latency Monitoring"
+					If((validStateProp $Setting ICALatencyMonitoring_Enable State ) -and ($Setting.ICALatencyMonitoring_Enable.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\ICA Latency Monitoring\Enable Monitoring"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ICALatencyMonitoring_Enable.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ICALatencyMonitoring_Enable.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ICALatencyMonitoring_Enable.State 
+						}
+					}
+					If((validStateProp $Setting ICALatencyMonitoring_Period State ) -and ($Setting.ICALatencyMonitoring_Period.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\ICA Latency Monitoring\Monitoring Period seconds"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ICALatencyMonitoring_Period.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ICALatencyMonitoring_Period.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ICALatencyMonitoring_Period.Value 
+						}
+					}
+					If((validStateProp $Setting ICALatencyMonitoring_Threshold State ) -and ($Setting.ICALatencyMonitoring_Threshold.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\ICA Latency Monitoring\Threshold milliseconds"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ICALatencyMonitoring_Threshold.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ICALatencyMonitoring_Threshold.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ICALatencyMonitoring_Threshold.Value 
+						}
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Monitoring"
@@ -25129,6 +25325,52 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
+					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Profile Load Time Monitoring"
+					If((validStateProp $Setting ProfileLoadTimeMonitoring_Enable State ) -and ($Setting.ProfileLoadTimeMonitoring_Enable.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Profile Load Time Monitoring\Enable Monitoring"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ProfileLoadTimeMonitoring_Enable.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ProfileLoadTimeMonitoring_Enable.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ProfileLoadTimeMonitoring_Enable.State 
+						}
+					}
+					If((validStateProp $Setting ProfileLoadTimeMonitoring_Threshold State ) -and ($Setting.ProfileLoadTimeMonitoring_Threshold.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Profile Load Time Monitoring\Threshold seconds"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ProfileLoadTimeMonitoring_Threshold.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ProfileLoadTimeMonitoring_Threshold.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ProfileLoadTimeMonitoring_Threshold.Value 
+						}
+					}
+
 					Write-Verbose "$(Get-Date): `t`t`tVirtual IP"
 					If((validStateProp $Setting VirtualLoopbackSupport State ) -and ($Setting.VirtualLoopbackSupport.State -ne "NotConfigured"))
 					{
@@ -25157,63 +25399,63 @@ Function ProcessCitrixPolicies
 						$txt = "Virtual IP\Virtual IP virtual loopback programs list"
 						If((validStateProp $Setting VirtualLoopbackPrograms State ) -and ($Setting.VirtualLoopbackPrograms.State -ne "NotConfigured"))
 						{
-						$tmpArray = $Setting.VirtualLoopbackPrograms.Values
-						$array = $Null
-						$tmp = ""
-						$cnt = 0
-						ForEach($Thing in $TmpArray)
-						{
-							If($Null -eq $Thing)
+							$tmpArray = $Setting.VirtualLoopbackPrograms.Values
+							$array = $Null
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
 							{
-								$Thing = ''
-							}
-							$cnt++
-							$tmp = "$($Thing) "
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Thing)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp
-								}
-							}
-							Else
-							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
-						}
-						$TmpArray = $Null
-						$tmp = $Null
+							$TmpArray = $Null
+							$tmp = $Null
 						}
 						Else
 						{
@@ -25320,15 +25562,15 @@ Function OutputPolicySetting
 {
 	Param([string] $outputText, [string] $outputData)
 
-	$xLength = $outputText.Length
-	If($outputText.Substring($xLength-2,2) -ne ": ")
+	If($outputText -ne "")
 	{
-		$outputText += ": "
+		$xLength = $outputText.Length
+		If($outputText.Substring($xLength-2,2) -ne ": ")
+		{
+			$outputText += ": "
+		}
 	}
-	If($Text)
-	{
-		Line 2 $outputText $outputData
-	}
+	Line 2 $outputText $outputData
 }
 
 Function Get-PrinterModifiedSettings

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -22,18 +22,18 @@
 	This script supports versions of XenApp/XenDesktop starting with 7.8.
 	
 	By default, only gives summary information for:
-		Machine Catalogs
-		AppDisks
-		Delivery Groups
-		Applications
-		Application Groups
-		Policies
-		Logging
 		Administrators
-		Hosting
-		StoreFront
 		App-V Publishing
+		AppDisks
 		AppDNA
+		Application Groups
+		Applications
+		Delivery Groups
+		Hosting
+		Logging
+		Machine Catalogs
+		Policies
+		StoreFront
 		Zones
 
 	The Summary information is what is shown in the top half of Citrix Studio for:
@@ -73,6 +73,45 @@
 		Spanish
 		Swedish
 		
+.PARAMETER AdminAddress
+	Specifies the address of a XenDesktop controller the PowerShell snapins will connect 
+	to. 
+	This can be provided as a host name or an IP address. 
+	This parameter defaults to LocalHost.
+	This parameter has an alias of AA.
+.PARAMETER CompanyAddress
+	Company Address to use for the Cover Page, if the Cover Page has the Address field.
+	
+	The following Cover Pages have an Address field:
+		Banded (Word 2013/2016)
+		Contrast (Word 2010)
+		Exposure (Word 2010)
+		Filigree (Word 2013/2016)
+		Ion (Dark) (Word 2013/2016)
+		Retrospect (Word 2013/2016)
+		Semaphore (Word 2013/2016)
+		Tiles (Word 2010)
+		ViewMaster (Word 2013/2016)
+		
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CA.
+.PARAMETER CompanyEmail
+	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
+	
+	The following Cover Pages have an Email field:
+		Facet (Word 2013/2016)
+	
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CE.
+.PARAMETER CompanyFax
+	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
+	
+	The following Cover Pages have a Fax field:
+		Contrast (Word 2010)
+		Exposure (Word 2010)
+	
+	This parameter is only valid with the MSWORD and PDF output parameters.
+	This parameter has an alias of CF.
 .PARAMETER CompanyName
 	Company Name to use for the Cover Page.  
 	The default value is contained in 
@@ -80,38 +119,13 @@
 	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated 
 	on the computer running the script.
 	This parameter has an alias of CN.
-.PARAMETER CompanyAddress
-	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
-		The following Cover Pages have an Address field:
-			Banded (Word 2013/2016)
-			Contrast (Word 2010)
-			Exposure (Word 2010)
-			Filigree (Word 2013/2016)
-			Ion (Dark) (Word 2013/2016)
-			Retrospect (Word 2013/2016)
-			Semaphore (Word 2013/2016)
-			Tiles (Word 2010)
-			ViewMaster (Word 2013/2016)
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CA.
-.PARAMETER CompanyEmail
-	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
-		The following Cover Pages have an Email field:
-			Facet (Word 2013/2016)
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CE.
-.PARAMETER CompanyFax
-	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
-		The following Cover Pages have a Fax field:
-			Contrast (Word 2010)
-			Exposure (Word 2010)
-	This parameter is only valid with the MSWORD and PDF output parameters.
-	This parameter has an alias of CF.
 .PARAMETER CompanyPhone
 	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
-		The following Cover Pages have a Phone field:
-			Contrast (Word 2010)
-			Exposure (Word 2010)
+	
+	The following Cover Pages have a Phone field:
+		Contrast (Word 2010)
+		Exposure (Word 2010)
+	
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CPh.
 .PARAMETER CoverPage
@@ -120,44 +134,44 @@
 	(default cover pages in Word en-US)
 
 	Valid input is:
-			Alphabet (Word 2010. Works)
-			Annual (Word 2010. Doesn't work well for this report)
-			Austere (Word 2010. Works)
-			Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
-			works in 2010 but Subtitle/Subject & Author fields need to be moved 
-			after title box is moved up)
-			Banded (Word 2013/2016. Works)
-			Conservative (Word 2010. Works)
-			Contrast (Word 2010. Works)
-			Cubicles (Word 2010. Works)
-			Exposure (Word 2010. Works if you like looking sideways)
-			Facet (Word 2013/2016. Works)
-			Filigree (Word 2013/2016. Works)
-			Grid (Word 2010/2013/2016. Works in 2010)
-			Integral (Word 2013/2016. Works)
-			Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
-			manually resized or font changed to 8 point)
-			Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
-			manually resized or font changed to 8 point)
-			Mod (Word 2010. Works)
-			Motion (Word 2010/2013/2016. Works if top date is manually changed to 
-			36 point)
-			Newsprint (Word 2010. Works but date is not populated)
-			Perspective (Word 2010. Works)
-			Pinstripes (Word 2010. Works)
-			Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
-			resized or font changed to 14 point)
-			Retrospect (Word 2013/2016. Works)
-			Semaphore (Word 2013/2016. Works)
-			Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
-			2010)
-			Slice (Dark) (Word 2013/2016. Doesn't work)
-			Slice (Light) (Word 2013/2016. Doesn't work)
-			Stacks (Word 2010. Works)
-			Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-			Transcend (Word 2010. Works)
-			ViewMaster (Word 2013/2016. Works)
-			Whisp (Word 2013/2016. Works)
+		Alphabet (Word 2010. Works)
+		Annual (Word 2010. Doesn't work well for this report)
+		Austere (Word 2010. Works)
+		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+		works in 2010 but Subtitle/Subject & Author fields need to be moved 
+		after title box is moved up)
+		Banded (Word 2013/2016. Works)
+		Conservative (Word 2010. Works)
+		Contrast (Word 2010. Works)
+		Cubicles (Word 2010. Works)
+		Exposure (Word 2010. Works if you like looking sideways)
+		Facet (Word 2013/2016. Works)
+		Filigree (Word 2013/2016. Works)
+		Grid (Word 2010/2013/2016. Works in 2010)
+		Integral (Word 2013/2016. Works)
+		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
+		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
+		Mod (Word 2010. Works)
+		Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+		36 point)
+		Newsprint (Word 2010. Works but date is not populated)
+		Perspective (Word 2010. Works)
+		Pinstripes (Word 2010. Works)
+		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+		resized or font changed to 14 point)
+		Retrospect (Word 2013/2016. Works)
+		Semaphore (Word 2013/2016. Works)
+		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+		2010)
+		Slice (Dark) (Word 2013/2016. Doesn't work)
+		Slice (Light) (Word 2013/2016. Doesn't work)
+		Stacks (Word 2010. Works)
+		Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+		Transcend (Word 2010. Works)
+		ViewMaster (Word 2013/2016. Works)
+		Whisp (Word 2013/2016. Works)
 
 	The default value is Sideline.
 	This parameter has an alias of CP.
@@ -167,12 +181,12 @@
 	The default value is contained in $env:username
 	This parameter has an alias of UN.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER AdminAddress
-	Specifies the address of a XenDesktop controller the PowerShell snapins will connect 
-	to. 
-	This can be provided as a host name or an IP address. 
-	This parameter defaults to LocalHost.
-	This parameter has an alias of AA.
+.PARAMETER HTML
+	Creates an HTML file with an .html extension.
+	This parameter is disabled by default.
+.PARAMETER MSWord
+	SaveAs DOCX file
+	This parameter is set True if no other output format is selected.
 .PARAMETER PDF
 	SaveAs PDF file instead of DOCX file.
 	This parameter is disabled by default.
@@ -182,29 +196,25 @@
 .PARAMETER Text
 	Creates a formatted text file with a .txt extension.
 	This parameter is disabled by default.
-.PARAMETER MSWord
-	SaveAs DOCX file
-	This parameter is set True if no other output format is selected.
-.PARAMETER HTML
-	Creates an HTML file with an .html extension.
+.PARAMETER Administrators
+	Give detailed information for Administrator Scopes and Roles.
 	This parameter is disabled by default.
-.PARAMETER MachineCatalogs
-	Gives detailed information for all machines in all Machine Catalogs.
-	
-	Using the MachineCatalogs parameter can cause the report to take a very long 
-	time to complete and can generate an extremely long report.
-	
-	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
-	report to take an extremely long time to complete and generate an exceptionally 
-	long report.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of MC.
+	This parameter has an alias of Admins.
 .PARAMETER AppDisks
 	Gives detailed information for all AppDisks.
 	
 	This parameter is disabled by default.
 	This parameter has an alias of AD.
+.PARAMETER Applications
+	Gives detailed information for all applications.
+	This parameter is disabled by default.
+	This parameter has an alias of Apps.
+.PARAMETER BrokerRegistryKeys
+	Adds information on 315 registry keys to the Controller section.
+	
+	For Word and PDF output, this adds eights pages, per Controller, to the report.
+	For Text and HTML, this adds 315 lines, per Controller, to the report.
+	This parameter has an alias of BRK.
 .PARAMETER DeliveryGroups
 	Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 	
@@ -229,10 +239,69 @@
 	
 	This parameter is disabled by default.
 	This parameter has an alias of DGU.
-.PARAMETER Applications
-	Gives detailed information for all applications.
+.PARAMETER Hosting
+	Give detailed information for Hosts, Host Connections, and Resources.
 	This parameter is disabled by default.
-	This parameter has an alias of Apps.
+	This parameter has an alias of Host.
+.PARAMETER Logging
+	Give the Configuration Logging report with, by default, details for the previous 
+	seven days.
+	This parameter is disabled by default.
+	This parameter has an alias of Log.
+.PARAMETER StartDate
+	Start date for the Configuration Logging report.
+	
+	Format for date only is MM/DD/YYYY.
+	
+	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+	The double quotes are needed.
+	
+	The default is today's date minus seven days.
+	This parameter has an alias of SD.
+.PARAMETER EndDate
+	End date for the Configuration Logging report.
+	
+	Format for date only is MM/DD/YYYY.
+	
+	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+	The double quotes are needed.
+	
+	The default is today's date.
+	This parameter has an alias of ED.
+.PARAMETER MachineCatalogs
+	Gives detailed information for all machines in all Machine Catalogs.
+	
+	Using the MachineCatalogs parameter can cause the report to take a very long 
+	time to complete and can generate an extremely long report.
+	
+	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
+	report to take an extremely long time to complete and generate an exceptionally 
+	long report.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of MC.
+.PARAMETER MaxDetails
+	Adds maximum detail to the report.
+	
+	This is the same as using the following parameters:
+		Administrators
+		AppDisks
+		Applications
+		BrokerRegistryKeys
+		DeliveryGroups
+		HardWare
+		Hosting
+		Logging
+		MachineCatalogs
+		Policies
+		StoreFront
+
+	Does not change the value of NoADPolicies.
+	
+	WARNING: Using this parameter can create an extremely large report and 
+	can take a very long time to run.
+
+	This parameter has an alias of MAX.
 .PARAMETER Policies
 	Give detailed information for both Site and Citrix AD based Policies.
 	
@@ -261,39 +330,6 @@
 	
 	This parameter is disabled by default.
 	This parameter has an alias of NoAD.
-.PARAMETER Logging
-	Give the Configuration Logging report with, by default, details for the previous 
-	seven days.
-	This parameter is disabled by default.
-	This parameter has an alias of Log.
-.PARAMETER Administrators
-	Give detailed information for Administrator Scopes and Roles.
-	This parameter is disabled by default.
-	This parameter has an alias of Admins.
-.PARAMETER Hosting
-	Give detailed information for Hosts, Host Connections, and Resources.
-	This parameter is disabled by default.
-	This parameter has an alias of Host.
-.PARAMETER StartDate
-	Start date for the Configuration Logging report.
-	
-	Format for date only is MM/DD/YYYY.
-	
-	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	The double quotes are needed.
-	
-	The default is today's date minus seven days.
-	This parameter has an alias of SD.
-.PARAMETER EndDate
-	End date for the Configuration Logging report.
-	
-	Format for date only is MM/DD/YYYY.
-	
-	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	The double quotes are needed.
-	
-	The default is today's date.
-	This parameter has an alias of ED.
 .PARAMETER StoreFront
 	Give detailed information for StoreFront.
 	This parameter is disabled by default.
@@ -305,6 +341,8 @@
 	Output filename will be ReportName_2017-06-01_1800.docx (or .pdf).
 	This parameter is disabled by default.
 	This parameter has an alias of ADT.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
 .PARAMETER Hardware
 	Use WMI to gather hardware information on Computer System, Disks, Processor and 
 	Network Interface Cards
@@ -344,8 +382,6 @@
 	Using Policies will force the Policies switch to True.
 	If Policies is selected and the NoPolicies switch is used, the script will terminate.
 	
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
 .PARAMETER SmtpServer
 	Specifies the optional email server to send the output report. 
 .PARAMETER SmtpPort
@@ -378,7 +414,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -390,7 +427,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -AdminAddress DDC01
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -402,7 +440,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -PDF
 	
 	Will use all default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -414,7 +453,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -TEXT
 
 	Will use all default values and save the document as a formatted text file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -425,7 +465,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -HTML
 
 	Will use all default values and save the document as an HTML file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -437,7 +478,8 @@
 	
 	Creates a report with full details for all machines in all Machine Catalogs.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -449,7 +491,8 @@
 	
 	Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -461,7 +504,8 @@
 	
 	Creates a report with utilization details for all Desktop (Delivery) Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -474,7 +518,8 @@
 	Creates a report with full details for all machines in all Machine Catalogs and 
 	all desktops in all Delivery Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -486,7 +531,8 @@
 	
 	Creates a report with full details for all applications.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -498,7 +544,8 @@
 	
 	Creates a report with full details for Policies.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -510,7 +557,8 @@
 	
 	Creates a report with no Policy information.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -522,7 +570,8 @@
 	
 	Creates a report with no Citrix AD based Policy information.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -536,7 +585,8 @@
 	no Citrix AD based Policy information.
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -549,7 +599,8 @@
 	Creates a report with full details on Administrator Scopes and Roles.
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -557,13 +608,15 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017 -EndDate 01/31/2017
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017
+	-EndDate 01/31/2017	
 	
 	Creates a report with Configuration Logging details for the dates 01/01/2017 through 
 	01/31/2017.
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -571,7 +624,8 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00" -EndDate "06/01/2017 14:00:00"
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
+	-EndDate "06/01/2017 14:00:00"	
 	
 	Creates a report with Configuration Logging details for the time range 
 	06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
@@ -579,7 +633,8 @@
 	Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -591,7 +646,8 @@
 	
 	Creates a report with full details for Hosts, Host Connections, and Resources.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -603,7 +659,8 @@
 	
 	Creates a report with full details for StoreFront.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -611,7 +668,8 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications -Policies -Hosting -StoreFront
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications
+	-Policies -Hosting -StoreFront	
 	
 	Creates a report with full details for all:
 		Machines in all Machine Catalogs
@@ -621,7 +679,8 @@
 		Hosts, Host Connections, and Resources
 		StoreFront
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -638,7 +697,8 @@
 		Policies
 		Hosts, Host Connections, and Resources
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -646,28 +706,30 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting" -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
-
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+	-CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+	
 	Will use:
 		Carl Webster Consulting for the Company Name.
 		Mod for the Cover Page format.
 		Carl Webster for the User Name.
 		Controller named DDC01 for the AdminAddress.
 .EXAMPLE
-	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster"
-
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+	-UN "Carl Webster"
+	
 	Will use:
 		Carl Webster Consulting for the Company Name (alias CN).
 		Mod for the Cover Page format (alias CP).
 		Carl Webster for the User Name (alias UN).
 		The computer running the script for the AdminAddress.
 .EXAMPLE
-	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" `
-	-CoverPage Exposure -UserName "Dr. Watson" `
-	-CompanyAddress "221B Baker Street, London, England" `
-	-CompanyFax "+44 1753 276600" `
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+	-CoverPage Exposure -UserName "Dr. Watson"
+	-CompanyAddress "221B Baker Street, London, England"
+	-CompanyFax "+44 1753 276600"
 	-CompanyPhone "+44 1753 276200"
-
+	
 	Will use:
 		Sherlock Holmes Consulting for the Company Name.
 		Exposure for the Cover Page format.
@@ -676,8 +738,8 @@
 		+44 1753 276600 for the Company Fax.
 		+44 1753 276200 for the Compnay Phone.
 .EXAMPLE
-	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" `
-	-CoverPage Facet -UserName "Dr. Watson" `
+	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+	-CoverPage Facet -UserName "Dr. Watson"
 	-CompanyEmail SuperSleuth@SherlockHolmes.com
 
 	Will use:
@@ -689,7 +751,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -AddDateTime
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -705,7 +768,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 	
 	Will use all Default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -721,7 +785,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Hardware
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -732,7 +797,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Folder \\FileServer\ShareName
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -742,10 +808,12 @@
 	
 	Output file will be saved in the path \\FileServer\ShareName
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld
+	-From XDAdmin@domain.tld -To ITGroup@domain.tld	
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -753,14 +821,20 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 	
-	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, sending to ITGroup@domain.tld.
+	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
+	sending to ITGroup@domain.tld.
+	
 	Script will use the default SMTP port 25 and will not use SSL.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+	-UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -768,13 +842,17 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 	
-	The script will use the email server smtp.office365.com on port 587 using SSL, sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	The script will use the email server smtp.office365.com on port 587 using SSL, 
+	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+	
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Policies
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -786,7 +864,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Groups -DG
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -798,7 +877,8 @@
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Groups
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -806,6 +886,47 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 	Processes only the Delivery Groups section of the report with no Delivery Group details.
+.EXAMPLE
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+	
+	Will use all Default values.
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+	$env:username = Administrator
+
+	Carl Webster for the Company Name.
+	Sideline for the Cover Page format.
+	Administrator for the User Name.
+	Adds the information on 315 Broker registry keys to the Controllers section.
+.EXAMPLE
+	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -MaxDetails
+	
+	Will use all Default values.
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or 
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+	$env:username = Administrator
+
+	Carl Webster for the Company Name.
+	Sideline for the Cover Page format.
+	Administrator for the User Name.
+	
+	Set the following parameter values:
+		Administrators      = True
+		AppDisks            = True
+		Applications        = True
+		BrokerRegistryKeys  = True
+		DeliveryGroups      = True
+		HardWare            = True
+		Hosting             = True
+		Logging             = True
+		MachineCatalogs     = True
+		Policies            = True
+		StoreFront          = True
+		
+		NoPolicies          = False
+		Section             = "All"
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
@@ -815,7 +936,7 @@
 	NAME: XD7_Inventory_V2.ps1
 	VERSION: 2.05
 	AUTHOR: Carl Webster
-	LASTEDIT: June 12, 2017
+	LASTEDIT: June 16, 2017
 #>
 
 #endregion
@@ -825,104 +946,11 @@
 [CmdletBinding(SupportsShouldProcess = $False, ConfirmImpact = "None", DefaultParameterSetName = "Word") ]
 
 Param(
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$MSWord=$False,
-
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$PDF=$False,
-
-	[parameter(ParameterSetName="Text",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$Text=$False,
-
-	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$HTML=$False,
-
 	[parameter(Mandatory=$False)] 
 	[ValidateNotNullOrEmpty()]
 	[Alias("AA")]
 	[string]$AdminAddress="LocalHost",
 
-	[parameter(Mandatory=$False)] 
-	[Alias("MC")]
-	[Switch]$MachineCatalogs=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("AD")]
-	[Switch]$AppDisks=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("DG")]
-	[Switch]$DeliveryGroups=$False,	
-
-	[parameter(Mandatory=$False)] 
-	[Alias("DGU")]
-	[Switch]$DeliveryGroupsUtilization=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Apps")]
-	[Switch]$Applications=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Pol")]
-	[Switch]$Policies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NP")]
-	[Switch]$NoPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NoAD")]
-	[Switch]$NoADPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Log")]
-	[Switch]$Logging=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Admins")]
-	[Switch]$Administrators=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Host")]
-	[Switch]$Hosting=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SF")]
-	[Switch]$StoreFront=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SD")]
-	[Datetime]$StartDate = ((Get-Date -displayhint date).AddDays(-7)),
-
-	[parameter(Mandatory=$False)] 
-	[Alias("ED")]
-	[Datetime]$EndDate = (Get-Date -displayhint date),
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("ADT")]
-	[Switch]$AddDateTime=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("HW")]
-	[Switch]$Hardware=$False,
-
-	[parameter(Mandatory=$False)] 
-	[string]$Section="All",
-	
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyName="",
-    
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
@@ -947,6 +975,13 @@ Param(
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("CN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyName="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("CPh")]
 	[ValidateNotNullOrEmpty()]
 	[string]$CompanyPhone="",
@@ -965,6 +1000,100 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$UserName=$env:username,
 
+	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$HTML=$False,
+
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$MSWord=$False,
+
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$PDF=$False,
+
+	[parameter(ParameterSetName="Text",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$Text=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Alias("Admins")]
+	[Switch]$Administrators=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("AD")]
+	[Switch]$AppDisks=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Apps")]
+	[Switch]$Applications=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("BRK")]
+	[Switch]$BrokerRegistryKeys=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Alias("DG")]
+	[Switch]$DeliveryGroups=$False,	
+
+	[parameter(Mandatory=$False)] 
+	[Alias("DGU")]
+	[Switch]$DeliveryGroupsUtilization=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Host")]
+	[Switch]$Hosting=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Log")]
+	[Switch]$Logging=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SD")]
+	[Datetime]$StartDate = ((Get-Date -displayhint date).AddDays(-7)),
+
+	[parameter(Mandatory=$False)] 
+	[Alias("ED")]
+	[Datetime]$EndDate = (Get-Date -displayhint date),
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("MC")]
+	[Switch]$MachineCatalogs=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("MAX")]
+	[Switch]$MaxDetails=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Alias("Pol")]
+	[Switch]$Policies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NP")]
+	[Switch]$NoPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NoAD")]
+	[Switch]$NoADPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SF")]
+	[Switch]$StoreFront=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("ADT")]
+	[Switch]$AddDateTime=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("HW")]
+	[Switch]$Hardware=$False,
+
+	[parameter(Mandatory=$False)] 
+	[string]$Section="All",
+	
 	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
 	[string]$SmtpServer="",
 
@@ -1006,14 +1135,30 @@ Param(
 #		Added Function Get-RegistryValue2
 #		Added Function Get-RegKeyToObject
 #		Added Function OutputControllerRegistryKeys
+#		Added new parameter BrokerRegistryKeys
 #		There are 315 registry keys and values that are checked and listed
 #		Updated Function OutputControllers
+#	Added Controller version information to the Controllers section
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added missing function validObject
+#	Added new parameter MaxDetails:
+#		This is the same as using the follwoing parameters:
+#			Administrators
+#			AppDisks
+#			Applications
+#			BrokerRegistryKeys
+#			DeliveryGroups
+#			HardWare
+#			Hosting
+#			Logging
+#			MachineCatalogs
+#			Policies
+#			StoreFront
 #	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
@@ -1025,16 +1170,18 @@ Param(
 #		Profile Streaming Exclusion list - directories
 #	Added to Delivery Group, LicenseModel and ProductCode
 #	Added Version information to Controllers
-#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
-#	Fix Function Check-LoadedModule
-#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
-#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
-#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
-#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Update Function ProcessScriptEnd for the new Cover Page properties
-#	Update Function ShowScriptOptions for the new Cover Page properties
-#	Update Function UpdateDocumentProperties for the new Cover Page properties
-#	Update help text
+#	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
+#	Fixed Function Check-LoadedModule
+#	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fixed numerous issues in the Policies section
+#	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
+#	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Reordered the parameters in the help text and parameter list so they match and are grouped better
+#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Updated Function ProcessScriptEnd for the new Cover Page properties
+#	Updated Function ShowScriptOptions for the new Cover Page properties
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated help text
 
 #Version 2.04 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM
@@ -1182,6 +1329,25 @@ Else
 	}
 	Write-Error "Unable to determine output parameter.  Script cannot continue"
 	Exit
+}
+
+#If the MaxDetails parameter is used, set a bunch of stuff true and some stuff false
+If($MaxDetails)
+{
+	$Administrators		= $True
+	$AppDisks			= $True
+	$Applications		= $True
+	$BrokerRegistryKeys	= $True
+	$DeliveryGroups		= $True
+	$HardWare			= $True
+	$Hosting			= $True
+	$Logging			= $True
+	$MachineCatalogs	= $True
+	$Policies			= $True
+	$StoreFront			= $True
+	
+	$NoPolicies			= $False
+	$Section			= "All"
 }
 
 If($NoPolicies)
@@ -5266,68 +5432,70 @@ Function ShowScriptOptions
 {
 	Write-Verbose "$(Get-Date): "
 	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Add DateTime    : $($AddDateTime)"
-	Write-Verbose "$(Get-Date): AdminAddress    : $($AdminAddress)"
-	Write-Verbose "$(Get-Date): Administrators  : $($Administrators)"
-	Write-Verbose "$(Get-Date): Applications    : $($Applications)"
-	Write-Verbose "$(Get-Date): Company Name    : $($Script:CoName)"
-	Write-Verbose "$(Get-Date): Company Address : $($CompanyAddress)"
-	Write-Verbose "$(Get-Date): Company Email   : $($CompanyEmail)"
-	Write-Verbose "$(Get-Date): Company Fax     : $($CompanyFax)"
-	Write-Verbose "$(Get-Date): Company Phone   : $($CompanyPhone)"
-	Write-Verbose "$(Get-Date): Cover Page      : $($CoverPage)"
-	Write-Verbose "$(Get-Date): DeliveryGroups  : $($DeliveryGroups)"
+	Write-Verbose "$(Get-Date): Add DateTime       : $($AddDateTime)"
+	Write-Verbose "$(Get-Date): AdminAddress       : $($AdminAddress)"
+	Write-Verbose "$(Get-Date): Administrators     : $($Administrators)"
+	Write-Verbose "$(Get-Date): Applications       : $($Applications)"
+	Write-Verbose "$(Get-Date): BrokerRegistryKeys : $($BrokerRegistryKeys)"
+	Write-Verbose "$(Get-Date): Company Name       : $($Script:CoName)"
+	Write-Verbose "$(Get-Date): Company Address    : $($CompanyAddress)"
+	Write-Verbose "$(Get-Date): Company Email      : $($CompanyEmail)"
+	Write-Verbose "$(Get-Date): Company Fax        : $($CompanyFax)"
+	Write-Verbose "$(Get-Date): Company Phone      : $($CompanyPhone)"
+	Write-Verbose "$(Get-Date): Cover Page         : $($CoverPage)"
+	Write-Verbose "$(Get-Date): DeliveryGroups     : $($DeliveryGroups)"
 	If($Dev)
 	{
-		Write-Verbose "$(Get-Date): DevErrorFile    : $($Script:DevErrorFile)"
+		Write-Verbose "$(Get-Date): DevErrorFile       : $($Script:DevErrorFile)"
 	}
-	Write-Verbose "$(Get-Date): DGUtilization   : $($DeliveryGroupsUtilization)"
-	Write-Verbose "$(Get-Date): Filename1       : $($Script:filename1)"
+	Write-Verbose "$(Get-Date): DGUtilization      : $($DeliveryGroupsUtilization)"
+	Write-Verbose "$(Get-Date): Filename1          : $($Script:filename1)"
 	If($PDF)
 	{
-		Write-Verbose "$(Get-Date): Filename2       : $($Script:Filename2)"
+		Write-Verbose "$(Get-Date): Filename2          : $($Script:Filename2)"
 	}
-	Write-Verbose "$(Get-Date): Folder          : $($Folder)"
-	Write-Verbose "$(Get-Date): From            : $($From)"
-	Write-Verbose "$(Get-Date): Hosting         : $($Hosting)"
-	Write-Verbose "$(Get-Date): HW Inventory    : $($Hardware)"
-	Write-Verbose "$(Get-Date): Logging         : $($Logging)"
+	Write-Verbose "$(Get-Date): Folder             : $($Folder)"
+	Write-Verbose "$(Get-Date): From               : $($From)"
+	Write-Verbose "$(Get-Date): Hosting            : $($Hosting)"
+	Write-Verbose "$(Get-Date): HW Inventory       : $($Hardware)"
+	Write-Verbose "$(Get-Date): Logging            : $($Logging)"
 	If($Logging)
 	{
-		Write-Verbose "$(Get-Date):    Start Date   : $($StartDate)"
-		Write-Verbose "$(Get-Date):    End Date     : $($EndDate)"
+		Write-Verbose "$(Get-Date):    Start Date      : $($StartDate)"
+		Write-Verbose "$(Get-Date):    End Date        : $($EndDate)"
 	}
-	Write-Verbose "$(Get-Date): MachineCatalogs : $($MachineCatalogs)"
-	Write-Verbose "$(Get-Date): NoADPolicies    : $($NoADPolicies)"
-	Write-Verbose "$(Get-Date): NoPolicies      : $($NoPolicies)"
-	Write-Verbose "$(Get-Date): Policies        : $($Policies)"
-	Write-Verbose "$(Get-Date): Save As PDF     : $($PDF)"
-	Write-Verbose "$(Get-Date): Save As HTML    : $($HTML)"
-	Write-Verbose "$(Get-Date): Save As TEXT    : $($TEXT)"
-	Write-Verbose "$(Get-Date): Save As WORD    : $($MSWORD)"
-	Write-Verbose "$(Get-Date): ScriptInfo      : $($ScriptInfo)"
-	Write-Verbose "$(Get-Date): Section         : $($Section)"
-	Write-Verbose "$(Get-Date): Site Name       : $($XDSiteName)"
-	Write-Verbose "$(Get-Date): Smtp Port       : $($SmtpPort)"
-	Write-Verbose "$(Get-Date): Smtp Server     : $($SmtpServer)"
-	Write-Verbose "$(Get-Date): StoreFront      : $($StoreFront)"
-	Write-Verbose "$(Get-Date): Title           : $($Script:Title)"
-	Write-Verbose "$(Get-Date): To              : $($To)"
-	Write-Verbose "$(Get-Date): Use SSL         : $($UseSSL)"
-	Write-Verbose "$(Get-Date): User Name       : $($UserName)"
-	Write-Verbose "$(Get-Date): XA/XD Version   : $($Script:XDSiteVersion)"
+	Write-Verbose "$(Get-Date): MachineCatalogs    : $($MachineCatalogs)"
+	Write-Verbose "$(Get-Date): MaxDetail          : $($MaxDetails)"
+	Write-Verbose "$(Get-Date): NoADPolicies       : $($NoADPolicies)"
+	Write-Verbose "$(Get-Date): NoPolicies         : $($NoPolicies)"
+	Write-Verbose "$(Get-Date): Policies           : $($Policies)"
+	Write-Verbose "$(Get-Date): Save As PDF        : $($PDF)"
+	Write-Verbose "$(Get-Date): Save As HTML       : $($HTML)"
+	Write-Verbose "$(Get-Date): Save As TEXT       : $($TEXT)"
+	Write-Verbose "$(Get-Date): Save As WORD       : $($MSWORD)"
+	Write-Verbose "$(Get-Date): ScriptInfo         : $($ScriptInfo)"
+	Write-Verbose "$(Get-Date): Section            : $($Section)"
+	Write-Verbose "$(Get-Date): Site Name          : $($XDSiteName)"
+	Write-Verbose "$(Get-Date): Smtp Port          : $($SmtpPort)"
+	Write-Verbose "$(Get-Date): Smtp Server        : $($SmtpServer)"
+	Write-Verbose "$(Get-Date): StoreFront         : $($StoreFront)"
+	Write-Verbose "$(Get-Date): Title              : $($Script:Title)"
+	Write-Verbose "$(Get-Date): To                 : $($To)"
+	Write-Verbose "$(Get-Date): Use SSL            : $($UseSSL)"
+	Write-Verbose "$(Get-Date): User Name          : $($UserName)"
+	Write-Verbose "$(Get-Date): XA/XD Version      : $($Script:XDSiteVersion)"
 	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): OS Detected     : $($Script:RunningOS)"
-	Write-Verbose "$(Get-Date): PoSH version    : $($Host.Version)"
-	Write-Verbose "$(Get-Date): PSCulture       : $($PSCulture)"
-	Write-Verbose "$(Get-Date): PSUICulture     : $($PSUICulture)"
+	Write-Verbose "$(Get-Date): OS Detected        : $($Script:RunningOS)"
+	Write-Verbose "$(Get-Date): PoSH version       : $($Host.Version)"
+	Write-Verbose "$(Get-Date): PSCulture          : $($PSCulture)"
+	Write-Verbose "$(Get-Date): PSUICulture        : $($PSUICulture)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Word language   : $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Word version    : $($Script:WordProduct)"
+		Write-Verbose "$(Get-Date): Word language      : $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date): Word version       : $($Script:WordProduct)"
 	}
 	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Script start    : $($Script:StartTime)"
+	Write-Verbose "$(Get-Date): Script start       : $($Script:StartTime)"
 	Write-Verbose "$(Get-Date): "
 	Write-Verbose "$(Get-Date): "
 }
@@ -6744,7 +6912,7 @@ Function ProcessAppDisks
 		{
 			$Global:TotalAppDisks++
 			
-			If($AppDisks)
+			If($AppDisk)
 			{
 				OutputAppDisk $AppDisk
 			}
@@ -9852,20 +10020,23 @@ Function OutputDeliveryGroupDetails
 			}
 		}
 		
-		If($DGExcludedUsers.Count -gt 0)
+		If($DGExcludedUsers -is [array])
 		{
-			$ScriptInformation += @{Data = "Excluded Users"; Value = $DGExcludedUsers[0]; }
-			$cnt = -1
-			ForEach($tmp in $DGExcludedUsers)
+			If($DGExcludedUsers.Count -gt 0)
 			{
-				$cnt++
-				If($cnt -gt 0)
+				$ScriptInformation += @{Data = "Excluded Users"; Value = $DGExcludedUsers[0]; }
+				$cnt = -1
+				ForEach($tmp in $DGExcludedUsers)
 				{
-					$ScriptInformation += @{Data = ""; Value = $tmp; }
+					$cnt++
+					If($cnt -gt 0)
+					{
+						$ScriptInformation += @{Data = ""; Value = $tmp; }
+					}
 				}
 			}
 		}
-
+		
 		If($Group.SessionSupport -eq "MultiSession")
 		{
 			$ScriptInformation += @{Data = 'Give access to unathenticated (anonymous) users'; Value = $SFAnonymousUsers; }
@@ -11151,9 +11322,12 @@ Function OutputDeliveryGroupCatalogs
 	
 	If($? -and $Null -ne $MCs)
 	{
-		If($MCs.Count -gt 1)
+		If($MCs -is [array])
 		{
-			[array]$MCs = $MCs | Sort -Unique
+			If($MCs.Count -gt 1)
+			{
+				[array]$MCs = $MCs | Sort -Unique
+			}
 		}
 		
 		$txt = "Machine Catalogs"
@@ -13146,6 +13320,19 @@ Function validStateProp( [object] $object, [string] $topLevel, [string] $secondL
 	Return $False
 }
 
+Function validObject( [object] $object, [string] $topLevel )
+{
+	#function created 8-jan-2014 by Michael B. Smith
+	If( $object )
+	{
+		If((gm -Name $topLevel -InputObject $object))
+		{
+			Return $True
+		}
+	}
+	Return $False
+}
+
 Function ProcessCitrixPolicies
 {
 	Param([string]$xDriveName, [string]$xPolicyType)
@@ -13960,63 +14147,88 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting ClientClipboardWriteAllowedFormats State ) -and ($Setting.ClientClipboardWriteAllowedFormats.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Client clipboard write allowed formats"
-						$tmpArray = $Setting.ClientClipboardWriteAllowedFormats.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Thing in $TmpArray)
+						If(validStateProp $Setting ClientClipboardWriteAllowedFormats Values )
 						{
-							If($Null -eq $Thing)
+							$tmpArray = $Setting.ClientClipboardWriteAllowedFormats.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
 							{
-								$Thing = ''
-							}
-							$cnt++
-							$tmp = "$($Thing) "
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Thing)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp
-								}
-							}
-							Else
-							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$txt = ""
 							}
-							$txt = ""
+							$TmpArray = $Null
+							$tmp = $Null
 						}
-						$TmpArray = $Null
-						$tmp = $Null
+						Else
+						{
+							$tmp = "No Client clipboard write allowed formats were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
+							}
+						}
 					}
 					If((validStateProp $Setting ClipboardSelectionUpdateMode State ) -and ($Setting.ClipboardSelectionUpdateMode.State -ne "NotConfigured"))
 					{
@@ -14329,125 +14541,175 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting SessionClipboardWriteAllowedFormats State ) -and ($Setting.SessionClipboardWriteAllowedFormats.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Session clipboard write allowed formats"
-						$tmpArray = $Setting.SessionClipboardWriteAllowedFormats.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Thing in $TmpArray)
+						If(validStateProp $Setting SessionClipboardWriteAllowedFormats Values )
 						{
-							If($Null -eq $Thing)
+							$tmpArray = $Setting.SessionClipboardWriteAllowedFormats.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
 							{
-								$Thing = ''
-							}
-							$cnt++
-							$tmp = "$($Thing) "
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Thing)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp
-								}
-							}
-							Else
-							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$txt = ""
 							}
-							$txt = ""
+							$TmpArray = $Null
+							$tmp = $Null
 						}
-						$TmpArray = $Null
-						$tmp = $Null
+						Else
+						{
+							$tmp = "No Session clipboard write allowed formats were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
+							}
+						}
 					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Adobe Flash Delivery\Flash Redirection"
 					If((validStateProp $Setting FlashUrlColorList State ) -and ($Setting.FlashUrlColorList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash background color list"
-						$Values = $Setting.FlashUrlColorList.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Value in $Values)
+						If(validStateProp $Setting FlashUrlColorList Values )
 						{
-							If($Null -eq $Value)
+							$Values = $Setting.FlashUrlColorList.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Value in $Values)
 							{
-								$Value = ''
-							}
-							$cnt++
-							$tmp = "$($Value)"
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Value)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Value = ''
+								}
+								$cnt++
+								$tmp = "$($Value)"
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp 
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp 
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
-							Else
+							$tmp = $Null
+							$Values = $Null
+						}
+						Else
+						{
+							$tmp = "No Flash background color list were found"
+							If($MSWord -or $PDF)
 							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
 								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
 							}
 						}
-						$tmp = $Null
-						$Values = $Null
 					}
 					If((validStateProp $Setting FlashBackwardsCompatibility State ) -and ($Setting.FlashBackwardsCompatibility.State -ne "NotConfigured"))
 					{
@@ -14550,62 +14812,87 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting FlashServerSideContentFetchingWhitelist State ) -and ($Setting.FlashServerSideContentFetchingWhitelist.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash server-side content fetching URL list"
-						$Values = $Setting.FlashServerSideContentFetchingWhitelist.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Value in $Values)
+						If(validStateProp $Setting FlashServerSideContentFetchingWhitelist Values )
 						{
-							If($Null -eq $Value)
+							$Values = $Setting.FlashServerSideContentFetchingWhitelist.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Value in $Values)
 							{
-								$Value = ''
-							}
-							$cnt++
-							$tmp = "$($Value)"
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Value)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Value = ''
+								}
+								$cnt++
+								$tmp = "$($Value)"
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp 
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp 
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
-							Else
+							$tmp = $Null
+							$Values = $Null
+						}
+						Else
+						{
+							$tmp = "No Flash server-side content fetching URL list were found"
+							If($MSWord -or $PDF)
 							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
 								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
 							}
 						}
-						$tmp = $Null
-						$Values = $Null
 					}
 					If((validStateProp $Setting FlashUrlCompatibilityList State ) -and ($Setting.FlashUrlCompatibilityList.State -ne "NotConfigured"))
 					{
@@ -14628,72 +14915,103 @@ Function ProcessCitrixPolicies
 						{
 							OutputPolicySetting $txt
 						}
-						$Values = $Setting.FlashUrlCompatibilityList.Values
-						$tmp = ""
-						ForEach($Value in $Values)
+						If(validStateProp $Setting FlashUrlCompatibilityList Values )
 						{
-							$Items = $Value.Split(' ')
-							$Action = $Items[0]
-							If($Action -eq "CLIENT")
+							$Values = $Setting.FlashUrlCompatibilityList.Values
+							$tmp = ""
+							ForEach($Value in $Values)
 							{
-								$Action = "Render On Client"
-							}
-							ElseIf($Action -eq "SERVER")
-							{
-								$Action = "Render On Server"
-							}
-							ElseIf($Action -eq "BLOCK")
-							{
-								$Action = "BLOCK           "
-							}
-							$Url = $Items[1]
-							If($Items.Count -eq 3)
-							{
-								$FlashInstance = $Items[2]
-							}
-							Else
-							{
-								$FlashInstance = "Any"
-							}
-							$tmp = "Action: $($Action)"
-							If($MSWord -or $PDF)
-							{
-								$WordTableRowHash = @{
-								Text = "";
-								Value = $tmp;
+								$Items = $Value.Split(' ')
+								$Action = $Items[0]
+								If($Action -eq "CLIENT")
+								{
+									$Action = "Render On Client"
 								}
-								$SettingsWordTable += $WordTableRowHash;
-							}
-							ElseIf($HTML)
-							{
-								$rowdata += @(,(
-								"",$htmlbold,
-								$tmp,$htmlwhite))
-							}
-							ElseIf($Text)
-							{
-								OutputPolicySetting "" $tmp
-							}
-							$tmp = "URL Pattern: $($Url)"
-							If($MSWord -or $PDF)
-							{
-								$WordTableRowHash = @{
-								Text = "";
-								Value = $tmp;
+								ElseIf($Action -eq "SERVER")
+								{
+									$Action = "Render On Server"
 								}
-								$SettingsWordTable += $WordTableRowHash;
+								ElseIf($Action -eq "BLOCK")
+								{
+									$Action = "BLOCK           "
+								}
+								$Url = $Items[1]
+								If($Items.Count -eq 3)
+								{
+									$FlashInstance = $Items[2]
+								}
+								Else
+								{
+									$FlashInstance = "Any"
+								}
+								$tmp = "Action: $($Action)"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = "";
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+								$tmp = "URL Pattern: $($Url)"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = "";
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+								$tmp = "Flash Instance: $($FlashInstance)"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = "";
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
 							}
-							ElseIf($HTML)
-							{
-								$rowdata += @(,(
-								"",$htmlbold,
-								$tmp,$htmlwhite))
-							}
-							ElseIf($Text)
-							{
-								OutputPolicySetting "" $tmp
-							}
-							$tmp = "Flash Instance: $($FlashInstance)"
+							$Values = $Null
+							$Action = $Null
+							$Url = $Null
+							$FlashInstance = $Null
+							$Spc = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Flash URL compatibility list were found"
 							If($MSWord -or $PDF)
 							{
 								$WordTableRowHash = @{
@@ -14713,12 +15031,6 @@ Function ProcessCitrixPolicies
 								OutputPolicySetting "" $tmp
 							}
 						}
-						$Values = $Null
-						$Action = $Null
-						$Url = $Null
-						$FlashInstance = $Null
-						$Spc = $Null
-						$tmp = $Null
 					}
 					If((validStateProp $Setting HDXFlashLoadManagement State ) -and ($Setting.HDXFlashLoadManagement.State -ne "NotConfigured"))
 					{
@@ -16428,122 +16740,172 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting URLRedirectionBlackList State ) -and ($Setting.URLRedirectionBlackList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Local App Access\URL redirection blacklist"
-						$tmpArray = $Setting.URLRedirectionBlackList.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Thing in $TmpArray)
+						If(validStateProp $Setting URLRedirectionBlackList Values )
 						{
-							If($Null -eq $Thing)
+							$tmpArray = $Setting.URLRedirectionBlackList.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
 							{
-								$Thing = ''
-							}
-							$cnt++
-							$tmp = "$($Thing) "
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Thing)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
-							Else
+							$TmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No URL redirection blacklist were found"
+							If($MSWord -or $PDF)
 							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
 								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
 							}
 						}
-						$TmpArray = $Null
-						$tmp = $Null
 					}
 					If((validStateProp $Setting URLRedirectionWhiteList State ) -and ($Setting.URLRedirectionWhiteList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Local App Access\URL redirection white list"
-						$tmpArray = $Setting.URLRedirectionWhiteList.Values
-						$tmp = ""
-						$cnt = 0
-						ForEach($Thing in $TmpArray)
+						If(validStateProp $Setting URLRedirectionWhiteList Values )
 						{
-							If($Null -eq $Thing)
+							$tmpArray = $Setting.URLRedirectionWhiteList.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
 							{
-								$Thing = ''
-							}
-							$cnt++
-							$tmp = "$($Thing) "
-							If($cnt -eq 1)
-							{
-								If($MSWord -or $PDF)
+								If($Null -eq $Thing)
 								{
-									$WordTableRowHash = @{
-									Text = $txt;
-									Value = $tmp;
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = $txt;
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
 								}
-								ElseIf($HTML)
+								Else
 								{
-									$rowdata += @(,(
-									$txt,$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting $txt $tmp
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
-							Else
+							$TmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No URL redirection white list were found"
+							If($MSWord -or $PDF)
 							{
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
 								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
 							}
 						}
-						$TmpArray = $Null
-						$tmp = $Null
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tICA\Mobile Experience"
@@ -17455,95 +17817,120 @@ Function ProcessCitrixPolicies
 						{
 							OutputPolicySetting $txt ""
 						}
-						$valArray = $Setting.SessionPrinters.Values
-						$tmp = ""
-						ForEach($printer in $valArray)
+						If(validStateProp $Setting SessionPrinters Values )
 						{
-							$prArray = $printer.Split(',')
-							ForEach($element in $prArray)
+							$valArray = $Setting.SessionPrinters.Values
+							$tmp = ""
+							ForEach($printer in $valArray)
 							{
-								If($element.SubString(0, 2) -eq "\\")
+								$prArray = $printer.Split(',')
+								ForEach($element in $prArray)
 								{
-									$index = $element.SubString(2).IndexOf('\')
-									If($index -ge 0)
+									If($element.SubString(0, 2) -eq "\\")
 									{
-										$server = $element.SubString(0, $index + 2)
-										$share  = $element.SubString($index + 3)
-										$tmp = "Server: $($server)"
-										If($MSWord -or $PDF)
+										$index = $element.SubString(2).IndexOf('\')
+										If($index -ge 0)
 										{
-											$WordTableRowHash = @{
-											Text = "";
-											Value = $tmp;
+											$server = $element.SubString(0, $index + 2)
+											$share  = $element.SubString($index + 3)
+											$tmp = "Server: $($server)"
+											If($MSWord -or $PDF)
+											{
+												$WordTableRowHash = @{
+												Text = "";
+												Value = $tmp;
+												}
+												$SettingsWordTable += $WordTableRowHash;
 											}
-											$SettingsWordTable += $WordTableRowHash;
-										}
-										ElseIf($HTML)
-										{
-											$rowdata += @(,(
-											"",$htmlbold,
-											$tmp,$htmlwhite))
-										}
-										ElseIf($Text)
-										{
-											OutputPolicySetting "" $tmp
-										}
-										$tmp = "Shared Name: $($share)"
-										If($MSWord -or $PDF)
-										{
-											$WordTableRowHash = @{
-											Text = "";
-											Value = $tmp;
+											ElseIf($HTML)
+											{
+												$rowdata += @(,(
+												"",$htmlbold,
+												$tmp,$htmlwhite))
 											}
-											$SettingsWordTable += $WordTableRowHash;
+											ElseIf($Text)
+											{
+												OutputPolicySetting "" $tmp
+											}
+											$tmp = "Shared Name: $($share)"
+											If($MSWord -or $PDF)
+											{
+												$WordTableRowHash = @{
+												Text = "";
+												Value = $tmp;
+												}
+												$SettingsWordTable += $WordTableRowHash;
+											}
+											ElseIf($HTML)
+											{
+												$rowdata += @(,(
+												"",$htmlbold,
+												$tmp,$htmlwhite))
+											}
+											ElseIf($Text)
+											{
+												OutputPolicySetting "" $tmp
+											}
 										}
-										ElseIf($HTML)
-										{
-											$rowdata += @(,(
-											"",$htmlbold,
-											$tmp,$htmlwhite))
-										}
-										ElseIf($Text)
-										{
-											OutputPolicySetting "" $tmp
-										}
+										$index = $Null
 									}
-									$index = $Null
-								}
-								Else
-								{
-									$tmp1 = $element.SubString(0, 4)
-									$tmp = Get-PrinterModifiedSettings $tmp1 $element
-									If(![String]::IsNullOrEmpty($tmp))
+									Else
 									{
-										If($MSWord -or $PDF)
+										$tmp1 = $element.SubString(0, 4)
+										$tmp = Get-PrinterModifiedSettings $tmp1 $element
+										If(![String]::IsNullOrEmpty($tmp))
 										{
-											$WordTableRowHash = @{
-											Text = "";
-											Value = $tmp;
+											If($MSWord -or $PDF)
+											{
+												$WordTableRowHash = @{
+												Text = "";
+												Value = $tmp;
+												}
+												$SettingsWordTable += $WordTableRowHash;
 											}
-											$SettingsWordTable += $WordTableRowHash;
+											ElseIf($HTML)
+											{
+												$rowdata += @(,(
+												"",$htmlbold,
+												$tmp,$htmlwhite))
+											}
+											ElseIf($Text)
+											{
+												OutputPolicySetting "" $tmp
+											}
 										}
-										ElseIf($HTML)
-										{
-											$rowdata += @(,(
-											"",$htmlbold,
-											$tmp,$htmlwhite))
-										}
-										ElseIf($Text)
-										{
-											OutputPolicySetting "" $tmp
-										}
+										$tmp1 = $Null
+										$tmp = $Null
 									}
-									$tmp1 = $Null
-									$tmp = $Null
 								}
 							}
-						}
 
-						$valArray = $Null
-						$prArray = $Null
-						$tmp = $Null
+							$valArray = $Null
+							$prArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Session printers were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = "";
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								"",$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting "" $tmp
+							}
+						}
 					}
 					If((validStateProp $Setting WaitForPrintersToBeCreated State ) -and ($Setting.WaitForPrintersToBeCreated.State -ne "NotConfigured"))
 					{
@@ -17700,192 +18087,217 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting PrinterDriverMappings State ) -and ($Setting.PrinterDriverMappings.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Client Printers\Printer driver mapping and compatibility"
-						$array = $Setting.PrinterDriverMappings.Values
-						$tmp = $array[0]
-						If($MSWord -or $PDF)
+						If(validStateProp $Setting PrinterDriverMappings Values )
 						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $tmp
-						}
-						
-						$cnt = -1
-						ForEach($element in $array)
-						{
-							$cnt++
-							
-							If($cnt -ne 0)
+							$array = $Setting.PrinterDriverMappings.Values
+							$tmp = $array[0]
+							If($MSWord -or $PDF)
 							{
-								$Items = $element.Split(',')
-								$DriverName = $Items[0]
-								$Action = $Items[1]
-								If($Action -match 'Replace=')
-								{
-									$ServerDriver = $Action.substring($Action.indexof("=")+1)
-									$Action = "Replace "
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
 								}
-								Else
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
+							}
+							
+							$cnt = -1
+							ForEach($element in $array)
+							{
+								$cnt++
+								
+								If($cnt -ne 0)
 								{
-									$ServerDriver = ""
-									If($Action -eq "Allow")
+									$Items = $element.Split(',')
+									$DriverName = $Items[0]
+									$Action = $Items[1]
+									If($Action -match 'Replace=')
 									{
-										$Action = "Allow "
+										$ServerDriver = $Action.substring($Action.indexof("=")+1)
+										$Action = "Replace "
 									}
-									ElseIf($Action -eq "Deny")
+									Else
 									{
-										$Action = "Do not create "
-									}
-									ElseIf($Action -eq "UPD_Only")
-									{
-										$Action = "Create with universal driver "
-									}
-								}
-								$tmp = "Driver Name: $($DriverName)"
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
-								$tmp = "Action: $($Action)"
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
-								$tmp = "Settings: "
-								If($MSWord -or $PDF)
-								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
-									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
-								}
-								If($Items.count -gt 2)
-								{
-									[int]$BeginAt = 2
-									[int]$EndAt = $Items.count
-									for ($i=$BeginAt;$i -lt $EndAt; $i++) 
-									{
-										$tmp2 = $Items[$i].SubString(0, 4)
-										$tmp = Get-PrinterModifiedSettings $tmp2 $Items[$i]
-										If(![String]::IsNullOrEmpty($tmp))
+										$ServerDriver = ""
+										If($Action -eq "Allow")
 										{
-											If($MSWord -or $PDF)
+											$Action = "Allow "
+										}
+										ElseIf($Action -eq "Deny")
+										{
+											$Action = "Do not create "
+										}
+										ElseIf($Action -eq "UPD_Only")
+										{
+											$Action = "Create with universal driver "
+										}
+									}
+									$tmp = "Driver Name: $($DriverName)"
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+									$tmp = "Action: $($Action)"
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+									$tmp = "Settings: "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+									If($Items.count -gt 2)
+									{
+										[int]$BeginAt = 2
+										[int]$EndAt = $Items.count
+										for ($i=$BeginAt;$i -lt $EndAt; $i++) 
+										{
+											$tmp2 = $Items[$i].SubString(0, 4)
+											$tmp = Get-PrinterModifiedSettings $tmp2 $Items[$i]
+											If(![String]::IsNullOrEmpty($tmp))
 											{
-												$WordTableRowHash = @{
-												Text = "";
-												Value = $tmp;
+												If($MSWord -or $PDF)
+												{
+													$WordTableRowHash = @{
+													Text = "";
+													Value = $tmp;
+													}
+													$SettingsWordTable += $WordTableRowHash;
 												}
-												$SettingsWordTable += $WordTableRowHash;
-											}
-											ElseIf($HTML)
-											{
-												$rowdata += @(,(
-												"",$htmlbold,
-												$tmp,$htmlwhite))
-											}
-											ElseIf($Text)
-											{
-												OutputPolicySetting "" $tmp
+												ElseIf($HTML)
+												{
+													$rowdata += @(,(
+													"",$htmlbold,
+													$tmp,$htmlwhite))
+												}
+												ElseIf($Text)
+												{
+													OutputPolicySetting "" $tmp
+												}
 											}
 										}
 									}
-								}
-								Else
-								{
-									$tmp = "Unmodified "
-									If($MSWord -or $PDF)
+									Else
 									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
+										$tmp = "Unmodified "
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
-								}
 
-								If(![String]::IsNullOrEmpty($ServerDriver))
-								{
-									$tmp = "Server Driver: $($ServerDriver)"
-									If($MSWord -or $PDF)
+									If(![String]::IsNullOrEmpty($ServerDriver))
 									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
+										$tmp = "Server Driver: $($ServerDriver)"
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$tmp = $Null
 								}
-								$tmp = $Null
+							}
+						}
+						Else
+						{
+							$tmp = "No Printer driver mapping and compatibility were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = "";
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								"",$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting "" $tmp
 							}
 						}
 					}
@@ -18169,59 +18581,84 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting LoadBalancedPrintServers State ) -and ($Setting.LoadBalancedPrintServers.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Universal Print Server\Universal Print Servers for load balancing"
-						$array = $Setting.LoadBalancedPrintServers.Values
-						$tmp = $array[0]
-						If($MSWord -or $PDF)
+						If(validStateProp $Setting LoadBalancedPrintServers Values )
 						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $tmp 
-						}
-
-						$txt = ""
-						$cnt = -1
-						
-						ForEach($element in $array)
-						{
-							$cnt++
-							
-							If($cnt -ne 0)
+							$array = $Setting.LoadBalancedPrintServers.Values
+							$tmp = $array[0]
+							If($MSWord -or $PDF)
 							{
-								$tmp = "$($element) "
-								If($MSWord -or $PDF)
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+
+							$txt = ""
+							$cnt = -1
+							
+							ForEach($element in $array)
+							{
+								$cnt++
+								
+								If($cnt -ne 0)
 								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									$tmp = "$($element) "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
+							$array = $Null
+							$tmp = $Null
 						}
-						$array = $Null
-						$tmp = $Null
+						Else
+						{
+							$tmp = "No Universal Print Servers for load balancing were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+						}
 					}
 					If((validStateProp $Setting PrintServersOutOfServiceThreshold State ) -and ($Setting.PrintServersOutOfServiceThreshold.State -ne "NotConfigured"))
 					{
@@ -19011,58 +19448,83 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting ClientUsbDeviceOptimizationRules State ) -and ($Setting.ClientUsbDeviceOptimizationRules.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\USB devices\Client USB device optimization rules"
-						$array = $Setting.ClientUsbDeviceOptimizationRules.Values
-						$tmp = $array[0]
-						If($MSWord -or $PDF)
+						If(validStateProp $Setting ClientUsbDeviceOptimizationRules Values )
 						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $tmp 
-						}
-
-						$txt = ""
-						$cnt = -1
-						ForEach($element in $array)
-						{
-							$cnt++
-							
-							If($cnt -ne 0)
+							$array = $Setting.ClientUsbDeviceOptimizationRules.Values
+							$tmp = $array[0]
+							If($MSWord -or $PDF)
 							{
-								$tmp = "$($element) "
-								If($MSWord -or $PDF)
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+
+							$txt = ""
+							$cnt = -1
+							ForEach($element in $array)
+							{
+								$cnt++
+								
+								If($cnt -ne 0)
 								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									$tmp = "$($element) "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
+							$array = $Null
+							$tmp = $Null
 						}
-						$array = $Null
-						$tmp = $Null
+						Else
+						{
+							$tmp = "No Client USB device optimization rules were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+						}
 					}
 					If((validStateProp $Setting UsbDeviceRedirection State ) -and ($Setting.UsbDeviceRedirection.State -ne "NotConfigured"))
 					{
@@ -19089,58 +19551,83 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting UsbDeviceRedirectionRules State ) -and ($Setting.UsbDeviceRedirectionRules.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\USB devices\Client USB device redirection rules"
-						$array = $Setting.UsbDeviceRedirectionRules.Values
-						$tmp = $array[0]
-						If($MSWord -or $PDF)
+						If(validStateProp $Setting UsbDeviceRedirectionRules Values )
 						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $tmp 
-						}
-
-						$txt = ""
-						$cnt = -1
-						ForEach($element in $array)
-						{
-							$cnt++
-							
-							If($cnt -ne 0)
+							$array = $Setting.UsbDeviceRedirectionRules.Values
+							$tmp = $array[0]
+							If($MSWord -or $PDF)
 							{
-								$tmp = "$($element) "
-								If($MSWord -or $PDF)
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+
+							$txt = ""
+							$cnt = -1
+							ForEach($element in $array)
+							{
+								$cnt++
+								
+								If($cnt -ne 0)
 								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									$tmp = "$($element) "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									$tmp,$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 							}
+							$array = $Null
+							$tmp = $Null
 						}
-						$array = $Null
-						$tmp = $Null
+						Else
+						{
+							$tmp = "No Client USB device redirections rules were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+						}
 					}
 					If((validStateProp $Setting UsbPlugAndPlayRedirection State ) -and ($Setting.UsbPlugAndPlayRedirection.State -ne "NotConfigured"))
 					{
@@ -19149,7 +19636,7 @@ Function ProcessCitrixPolicies
 						{
 							$WordTableRowHash = @{
 							Text = $txt;
-							Value = $Setting.UsbPlugAndPlayRedirection.Value;
+							Value = $Setting.UsbPlugAndPlayRedirection.State;
 							}
 							$SettingsWordTable += $WordTableRowHash;
 						}
@@ -19157,11 +19644,11 @@ Function ProcessCitrixPolicies
 						{
 							$rowdata += @(,(
 							$txt,$htmlbold,
-							$Setting.UsbPlugAndPlayRedirection.Value,$htmlwhite))
+							$Setting.UsbPlugAndPlayRedirection.State,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							OutputPolicySetting $txt $Setting.UsbPlugAndPlayRedirection.Value 
+							OutputPolicySetting $txt $Setting.UsbPlugAndPlayRedirection.State 
 						}
 					}
 
@@ -20091,58 +20578,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Basic settings\Excluded groups"
 						If($Setting.ExcludedGroups_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.ExcludedGroups_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting ExcludedGroups_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.ExcludedGroups_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Excluded groups were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -20261,58 +20773,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Basic settings\Processed groups"
 						If($Setting.ProcessedGroups_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.ProcessedGroups_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting ProcessedGroups_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.ProcessedGroups_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Processed groups were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}	
 						Else
 						{
@@ -20343,58 +20880,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Cross-Platform settings\Cross-platform settings user groups"
 						If($Setting.CPUserGroups_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.CPUserGroups_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting CPUserGroups_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.CPUserGroups_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Cross-platform settings user groups were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -21247,58 +21809,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\File system\Exclusions\Exclusion list - directories"
 						If($Setting.ExclusionListSyncDir_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.ExclusionListSyncDir_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting ExclusionListSyncDir_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.ExclusionListSyncDir_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Exclusion list - directories were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -21327,58 +21914,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\File system\Exclusions\Exclusion list - files"
 						If($Setting.ExclusionListSyncFiles_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.ExclusionListSyncFiles_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting ExclusionListSyncFiles_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.ExclusionListSyncFiles_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Exclusion list - files were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -21409,58 +22021,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\File system\Synchronization\Directories to synchronize"
 						If($Setting.SyncDirList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.SyncDirList_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting SyncDirList_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.SyncDirList_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Directories to synchronize were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -21489,58 +22126,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\File system\Synchronization\Files to synchronize"
 						If($Setting.SyncFileList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.SyncFileList_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting SyncFileList_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.SyncFileList_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Files to synchronize were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -21569,58 +22231,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\File system\Synchronization\Folders to mirror"
 						If($Setting.MirrorFoldersList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.MirrorFoldersList_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting MirrorFoldersList_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.MirrorFoldersList_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Folders to mirror were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -23243,58 +23930,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Registry\Exclusion list"
 						If($Setting.ExclusionList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.ExclusionList_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting ExclusionList_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.ExclusionList_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Exclusion list were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -23323,58 +24035,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Registry\Inclusion list"
 						If($Setting.IncludeListRegistry_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.IncludeListRegistry_Part.Values
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting IncludeListRegistry_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.IncludeListRegistry_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Inclusion list were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -23536,7 +24273,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting PSAlwaysCache_Part State ) -and ($Setting.PSAlwaysCache_Part.State -ne "NotConfigured"))
 					{
-						$txt = "Profile Management\Streamed user profiles\Always cache size"
+						$txt = "Profile Management\Streamed user profiles\Always cache size (MB)"
 						If($Setting.PSAlwaysCache_Part.State -eq "Enabled")
 						{
 							If($MSWord -or $PDF)
@@ -23607,58 +24344,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Streamed user profiles\Profile Streaming Exclusion list - directories"
 						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.StreamingExclusionList_Part.Values.Split(",")
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting StreamingExclusionList_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.StreamingExclusionList_Part.Values.Split(",")
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Profile Streaming Exclusion list - directories were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -23687,58 +24449,83 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Streamed user profiles\Streamed user profile groups"
 						If($Setting.PSUserGroups_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.PSUserGroups_Part.Values.Split(",")
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting PSUserGroups_Part Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.PSUserGroups_Part.Values.Split(",")
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Streamed user profile groups were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -23808,68 +24595,101 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt ""
 						}
 						$txt = ""
-						$tmpArray = $Setting.StorefrontAccountsList.Values
-						ForEach($Thing in $TmpArray)
+						If(validStateProp $Setting StorefrontAccountsList Values )
 						{
-							$cnt++
-							$xxx = """$($Thing)"""
-							[array]$tmp = $xxx.Split(";").replace('"','')
-							$tmp1 = "Name: $($tmp[0])"
-							$tmp2 = "URL: $($tmp[1])"
-							$tmp3 = "State: $($tmp[2])"
-							$tmp4 = "Desc: $($tmp[3])"
-							If($MSWord -or $PDF)
+							$tmpArray = $Setting.StorefrontAccountsList.Values
+							ForEach($Thing in $TmpArray)
 							{
-								$WordTableRowHash = @{
-								Text = $txt;
-								Value = $tmp1;
+								$cnt++
+								$xxx = """$($Thing)"""
+								[array]$tmp = $xxx.Split(";").replace('"','')
+								$tmp1 = "Name: $($tmp[0])"
+								$tmp2 = "URL: $($tmp[1])"
+								$tmp3 = "State: $($tmp[2])"
+								$tmp4 = "Desc: $($tmp[3])"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp1;
+									}
+									$SettingsWordTable += $WordTableRowHash
+									
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp2;
+									}
+									$SettingsWordTable += $WordTableRowHash
+									
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp3;
+									}
+									$SettingsWordTable += $WordTableRowHash
+									
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp4;
+									}
+									$SettingsWordTable += $WordTableRowHash
 								}
-								$SettingsWordTable += $WordTableRowHash
-								
-								$WordTableRowHash = @{
-								Text = $txt;
-								Value = $tmp2;
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp1,$htmlwhite))
+									
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp2,$htmlwhite))
+									
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp3,$htmlwhite))
+									
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp4,$htmlwhite))
 								}
-								$SettingsWordTable += $WordTableRowHash
-								
-								$WordTableRowHash = @{
-								Text = $txt;
-								Value = $tmp3;
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp1
+									OutputPolicySetting $txt $tmp2
+									OutputPolicySetting $txt $tmp3
+									OutputPolicySetting $txt $tmp4
 								}
-								$SettingsWordTable += $WordTableRowHash
-								
-								$WordTableRowHash = @{
-								Text = $txt;
-								Value = $tmp4;
+								$tmp = " "
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = "";
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
 								}
-								$SettingsWordTable += $WordTableRowHash
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									"",$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+								$xxx = $Null
+								$tmp = $Null
+								$tmp1 = $Null
+								$tmp2 = $Null
+								$tmp3 = $Null
+								$tmp4 = $Null
 							}
-							ElseIf($HTML)
-							{
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								$tmp1,$htmlwhite))
-								
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								$tmp2,$htmlwhite))
-								
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								$tmp3,$htmlwhite))
-								
-								$rowdata += @(,(
-								$txt,$htmlbold,
-								$tmp4,$htmlwhite))
-							}
-							ElseIf($Text)
-							{
-								OutputPolicySetting $txt $tmp1
-								OutputPolicySetting $txt $tmp2
-								OutputPolicySetting $txt $tmp3
-								OutputPolicySetting $txt $tmp4
-							}
-							$tmp = " "
+							$TmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Storefront accounts list were found"
 							If($MSWord -or $PDF)
 							{
 								$WordTableRowHash = @{
@@ -23888,15 +24708,7 @@ Function ProcessCitrixPolicies
 							{
 								OutputPolicySetting "" $tmp
 							}
-							$xxx = $Null
-							$tmp = $Null
-							$tmp1 = $Null
-							$tmp2 = $Null
-							$tmp3 = $Null
-							$tmp4 = $Null
 						}
-						$TmpArray = $Null
-						$tmp = $Null
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings"
@@ -24170,58 +24982,83 @@ Function ProcessCitrixPolicies
 						$txt = "Virtual Delivery Agent Settings\Monitoring\List of applications excluded from failure monitoring"
 						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
 						{
-							$tmpArray = $Setting.AppFailureExclusionList.Values.Split(",")
-							$tmp = ""
-							$cnt = 0
-							ForEach($Thing in $tmpArray)
+							If(validStateProp $Setting AppFailureExclusionList Values )
 							{
-								$cnt++
-								$tmp = "$($Thing)"
-								If($cnt -eq 1)
+								$tmpArray = $Setting.AppFailureExclusionList.Values.Split(",")
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
 								{
-									If($MSWord -or $PDF)
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
 									{
-										$WordTableRowHash = @{
-										Text = $txt;
-										Value = $tmp;
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
 										}
-										$SettingsWordTable += $WordTableRowHash;
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
 									}
-									ElseIf($HTML)
+									Else
 									{
-										$rowdata += @(,(
-										$txt,$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting $txt $tmp
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
 									}
 								}
-								Else
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No List of applications excluded from failure monitoring were found"
+								If($MSWord -or $PDF)
 								{
-									If($MSWord -or $PDF)
-									{
-										$WordTableRowHash = @{
-										Text = "";
-										Value = $tmp;
-										}
-										$SettingsWordTable += $WordTableRowHash;
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
 									}
-									ElseIf($HTML)
-									{
-										$rowdata += @(,(
-										"",$htmlbold,
-										$tmp,$htmlwhite))
-									}
-									ElseIf($Text)
-									{
-										OutputPolicySetting "" $tmp
-									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
 								}
 							}
-							$tmpArray = $Null
-							$tmp = $Null
 						}
 						Else
 						{
@@ -24318,6 +25155,8 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting VirtualLoopbackPrograms State ) -and ($Setting.VirtualLoopbackPrograms.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual IP\Virtual IP virtual loopback programs list"
+						If((validStateProp $Setting VirtualLoopbackPrograms State ) -and ($Setting.VirtualLoopbackPrograms.State -ne "NotConfigured"))
+						{
 						$tmpArray = $Setting.VirtualLoopbackPrograms.Values
 						$array = $Null
 						$tmp = ""
@@ -24375,6 +25214,29 @@ Function ProcessCitrixPolicies
 						}
 						$TmpArray = $Null
 						$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Virtual IP virtual loopback programs list were found"
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $tmp;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
+							}
+						}
 					}
 				}
 				If($MSWord -or $PDF)
@@ -26677,65 +27539,65 @@ Function GetRolePermissions
 			"Catalog_RemoveScope"										{$Results.Add("Remove Machine Catalog from Scope", "Machine Catalogs"); Break}
 			"Catalog_SessionManagement"									{$Results.Add("Perform session management on machines via Machine Catalog membership", "Machine Catalogs"); Break}
 			"Catalog_UpdateMasterImage"									{$Results.Add("Perform Machine update", "Machine Catalogs"); Break}
-			"Configuration_Read"										{$Results.Add("Read Site Configuration", "Other permissions"); Break}
-			"Configuration_Write"										{$Results.Add("Update Site Configuration", "Other permissions"); Break}
+			"Configuration_Read"										{$Results.Add("Read Site Configuration (Configuration_Read)", "Other permissions"); Break}
+			"Configuration_Write"										{$Results.Add("Update Site Configuration (Configuration_Write)", "Other permissions"); Break}
 			"Controllers_Remove"										{$Results.Add("Remove Delivery Controller", "Controllers"); Break}
-			"DesktopGroup_AddApplication" {$Results.Add("Add Application to Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_AddMachines" {$Results.Add("Add Machines to Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_AddScope" {$Results.Add("Add Delivery Group to Scope", "Delivery Groups"); Break}
-			"DesktopGroup_ChangeMachineMaintenanceMode" {$Results.Add("Enable/disable maintenance mode of a machine via Delivery Group membership", "Delivery Groups"); Break}
-			"DesktopGroup_ChangeMaintenanceMode" {$Results.Add("Enable/disable maintenance mode of a Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_ChangeTags" {$Results.Add("Edit Delivery Group tags", "Delivery Groups"); Break}
-			"DesktopGroup_ChangeUserAssignment" {$Results.Add("Change users assigned to a desktop", "Delivery Groups"); Break}
-			"DesktopGroup_Create" {$Results.Add("Create Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_Delete" {$Results.Add("Delete Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_EditProperties" {$Results.Add("Edit Delivery Group Properties", "Delivery Groups"); Break}
-			"DesktopGroup_PowerOperations_RDS" {$Results.Add("Perform power operations on Windows Server machines via Delivery Group membership", "Delivery Groups"); Break}
-			"DesktopGroup_PowerOperations_VDI" {$Results.Add("Perform power operations on Windows Desktop machines via Delivery Group membership", "Delivery Groups"); Break}
-			"DesktopGroup_Read" {$Results.Add("View Delivery Groups", "Delivery Groups"); Break}
-			"DesktopGroup_RemoveApplication" {$Results.Add("Remove Application from Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_RemoveDesktop" {$Results.Add("Remove Desktop from Delivery Group", "Delivery Groups"); Break}
-			"DesktopGroup_RemoveScope" {$Results.Add("Remove Delivery Group from Scope", "Delivery Groups"); Break}
-			"DesktopGroup_SessionManagement" {$Results.Add("Perform session management on machines via Delivery Group membership", "Delivery Groups"); Break}
-			"Director_ClientDetails_Read" {$Results.Add("View Client Details page", "Director"); Break}
-			"Director_ClientHelpDesk_Read" {$Results.Add("View Client Activity Manager page", "Director"); Break}
-			"Director_Dashboard_Read" {$Results.Add("View Dashboard page", "Director"); Break}
-			"Director_DesktopHardwareInformation_Edit" {$Results.Add("Edit Machine Hardware related Broker machine command properties", "Director"); Break}
-			"Director_HDXInformation_Edit" {$Results.Add("Edit HDX related Broker machine command properties", "Director"); Break}
-			"Director_HelpDesk_Read" {$Results.Add("View Activity Manager page", "Director"); Break}
-			"Director_KillApplication" {$Results.Add("Perform Kill Application running on a machine", "Director"); Break}
-			"Director_KillApplication_Edit" {$Results.Add("Edit Kill Application related Broker machine command properties", "Director"); Break}
-			"Director_KillProcess" {$Results.Add("Perform Kill Process running on a machine", "Director"); Break}
-			"Director_KillProcess_Edit" {$Results.Add("Edit Kill Process related Broker machine command properties", "Director"); Break}
-			"Director_LatencyInformation_Edit" {$Results.Add("Edit Latency related Broker machine command properties", "Director"); Break}
-			"Director_MachineDetails_Read" {$Results.Add("View Machine Details page", "Director"); Break}
-			"Director_MachineMetricValues_Edit" {$Results.Add("Edit Machine metric related Broker machine command properties", "Director"); Break}
-			"Director_PersonalizationInformation_Edit" {$Results.Add("Edit Personalization related Broker machine command properties", "Director"); Break}
-			"Director_PoliciesInformation_Edit" {$Results.Add("Edit Policies related Broker machine command properties", "Director"); Break}
-			"Director_ResetVDisk" {$Results.Add("Perform Reset VDisk operation", "Director"); Break}
-			"Director_ResetVDisk_Edit" {$Results.Add("Edit Reset VDisk related Broker machine command properties", "Director"); Break}
-			"Director_RoundTripInformation_Edit" {$Results.Add("Edit Roundtrip Time related Broker machine command properties", "Director"); Break}
-			"Director_ShadowSession" {$Results.Add("Perform Remote Assistance on a machine", "Director"); Break}
-			"Director_ShadowSession_Edit" {$Results.Add("Edit Remote Assistance related Broker machine command properties", "Director"); Break}
-			"Director_SliceAndDice_Read" {$Results.Add("View Filters page", "Director"); Break}
-			"Director_TaskManagerInformation_Edit" {$Results.Add("Edit Task Manager related Broker machine command properties", "Director"); Break}
-			"Director_Trends_Read" {$Results.Add("View Trends page", "Director"); Break}
-			"Director_UserDetails_Read" {$Results.Add("View User Details page", "Director"); Break}
-			"Director_WindowsSessionId_Edit" {$Results.Add("Edit Windows Sessionid related Broker machine command properties", "Director"); Break}
-			"EnvTest" {$Results.Add("Run environment tests", "Other permissions"); Break}
-			"Global_Read" {$Results.Add("Read Site Configuration", "Other permissions"); Break}
-			"Global_Write" {$Results.Add("Update Site Configuration", "Other permissions"); Break}
-			"Hosts_AddScope" {$Results.Add("Add Host Connection to Scope", "Hosts"); Break}
-			"Hosts_AddStorage" {$Results.Add("Add storage to Resources", "Hosts"); Break}
-			"Hosts_ChangeMaintenanceMode" {$Results.Add("Enable/disable maintenance mode of a Host Connection", "Hosts"); Break}
-			"Hosts_Consume" {$Results.Add("Use Host Connection or Resources to Create Catalog", "Hosts"); Break}
-			"Hosts_CreateHost" {$Results.Add("Add Host Connection or Resources", "Hosts"); Break}
-			"Hosts_DeleteConnection" {$Results.Add("Delete Host Connection", "Hosts"); Break}
-			"Hosts_DeleteHost" {$Results.Add("Delete Resources", "Hosts"); Break}
-			"Hosts_EditConnectionProperties" {$Results.Add("Edit Host Connection properties", "Hosts"); Break}
-			"Hosts_EditHostProperties" {$Results.Add("Edit Resources", "Hosts"); Break}
-			"Hosts_Read" {$Results.Add("View Host Connections and Resources", "Hosts"); Break}
-			"Hosts_RemoveScope" {$Results.Add("Remove Host Connection from Scope", "Hosts"); Break}
+			"DesktopGroup_AddApplication"								{$Results.Add("Add Application to Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_AddMachines"									{$Results.Add("Add Machines to Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_AddScope"										{$Results.Add("Add Delivery Group to Scope", "Delivery Groups"); Break}
+			"DesktopGroup_ChangeMachineMaintenanceMode"					{$Results.Add("Enable/disable maintenance mode of a machine via Delivery Group membership", "Delivery Groups"); Break}
+			"DesktopGroup_ChangeMaintenanceMode"						{$Results.Add("Enable/disable maintenance mode of a Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_ChangeTags"									{$Results.Add("Edit Delivery Group tags", "Delivery Groups"); Break}
+			"DesktopGroup_ChangeUserAssignment"							{$Results.Add("Change users assigned to a desktop", "Delivery Groups"); Break}
+			"DesktopGroup_Create"										{$Results.Add("Create Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_Delete"										{$Results.Add("Delete Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_EditProperties"								{$Results.Add("Edit Delivery Group Properties", "Delivery Groups"); Break}
+			"DesktopGroup_PowerOperations_RDS"							{$Results.Add("Perform power operations on Windows Server machines via Delivery Group membership", "Delivery Groups"); Break}
+			"DesktopGroup_PowerOperations_VDI"							{$Results.Add("Perform power operations on Windows Desktop machines via Delivery Group membership", "Delivery Groups"); Break}
+			"DesktopGroup_Read"											{$Results.Add("View Delivery Groups", "Delivery Groups"); Break}
+			"DesktopGroup_RemoveApplication"							{$Results.Add("Remove Application from Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_RemoveDesktop"								{$Results.Add("Remove Desktop from Delivery Group", "Delivery Groups"); Break}
+			"DesktopGroup_RemoveScope"									{$Results.Add("Remove Delivery Group from Scope", "Delivery Groups"); Break}
+			"DesktopGroup_SessionManagement"							{$Results.Add("Perform session management on machines via Delivery Group membership", "Delivery Groups"); Break}
+			"Director_ClientDetails_Read"								{$Results.Add("View Client Details page", "Director"); Break}
+			"Director_ClientHelpDesk_Read"								{$Results.Add("View Client Activity Manager page", "Director"); Break}
+			"Director_Dashboard_Read"									{$Results.Add("View Dashboard page", "Director"); Break}
+			"Director_DesktopHardwareInformation_Edit"					{$Results.Add("Edit Machine Hardware related Broker machine command properties", "Director"); Break}
+			"Director_HDXInformation_Edit"								{$Results.Add("Edit HDX related Broker machine command properties", "Director"); Break}
+			"Director_HelpDesk_Read"									{$Results.Add("View Activity Manager page", "Director"); Break}
+			"Director_KillApplication"									{$Results.Add("Perform Kill Application running on a machine", "Director"); Break}
+			"Director_KillApplication_Edit"								{$Results.Add("Edit Kill Application related Broker machine command properties", "Director"); Break}
+			"Director_KillProcess"										{$Results.Add("Perform Kill Process running on a machine", "Director"); Break}
+			"Director_KillProcess_Edit"									{$Results.Add("Edit Kill Process related Broker machine command properties", "Director"); Break}
+			"Director_LatencyInformation_Edit"							{$Results.Add("Edit Latency related Broker machine command properties", "Director"); Break}
+			"Director_MachineDetails_Read"								{$Results.Add("View Machine Details page", "Director"); Break}
+			"Director_MachineMetricValues_Edit"							{$Results.Add("Edit Machine metric related Broker machine command properties", "Director"); Break}
+			"Director_PersonalizationInformation_Edit"					{$Results.Add("Edit Personalization related Broker machine command properties", "Director"); Break}
+			"Director_PoliciesInformation_Edit"							{$Results.Add("Edit Policies related Broker machine command properties", "Director"); Break}
+			"Director_ResetVDisk"										{$Results.Add("Perform Reset VDisk operation", "Director"); Break}
+			"Director_ResetVDisk_Edit"									{$Results.Add("Edit Reset VDisk related Broker machine command properties", "Director"); Break}
+			"Director_RoundTripInformation_Edit"						{$Results.Add("Edit Roundtrip Time related Broker machine command properties", "Director"); Break}
+			"Director_ShadowSession"									{$Results.Add("Perform Remote Assistance on a machine", "Director"); Break}
+			"Director_ShadowSession_Edit"								{$Results.Add("Edit Remote Assistance related Broker machine command properties", "Director"); Break}
+			"Director_SliceAndDice_Read"								{$Results.Add("View Filters page", "Director"); Break}
+			"Director_TaskManagerInformation_Edit"						{$Results.Add("Edit Task Manager related Broker machine command properties", "Director"); Break}
+			"Director_Trends_Read"										{$Results.Add("View Trends page", "Director"); Break}
+			"Director_UserDetails_Read"									{$Results.Add("View User Details page", "Director"); Break}
+			"Director_WindowsSessionId_Edit"							{$Results.Add("Edit Windows Sessionid related Broker machine command properties", "Director"); Break}
+			"EnvTest"													{$Results.Add("Run environment tests", "Other permissions"); Break}
+			"Global_Read"												{$Results.Add("Read Site Configuration (Global_Read)", "Other permissions"); Break}
+			"Global_Write"												{$Results.Add("Update Site Configuration (Global_Write)", "Other permissions"); Break}
+			"Hosts_AddScope"											{$Results.Add("Add Host Connection to Scope", "Hosts"); Break}
+			"Hosts_AddStorage"											{$Results.Add("Add storage to Resources", "Hosts"); Break}
+			"Hosts_ChangeMaintenanceMode"								{$Results.Add("Enable/disable maintenance mode of a Host Connection", "Hosts"); Break}
+			"Hosts_Consume"												{$Results.Add("Use Host Connection or Resources to Create Catalog", "Hosts"); Break}
+			"Hosts_CreateHost"											{$Results.Add("Add Host Connection or Resources", "Hosts"); Break}
+			"Hosts_DeleteConnection"									{$Results.Add("Delete Host Connection", "Hosts"); Break}
+			"Hosts_DeleteHost"											{$Results.Add("Delete Resources", "Hosts"); Break}
+			"Hosts_EditConnectionProperties"							{$Results.Add("Edit Host Connection properties", "Hosts"); Break}
+			"Hosts_EditHostProperties"									{$Results.Add("Edit Resources", "Hosts"); Break}
+			"Hosts_Read"												{$Results.Add("View Host Connections and Resources", "Hosts"); Break}
+			"Hosts_RemoveScope"											{$Results.Add("Remove Host Connection from Scope", "Hosts"); Break}
 			"Licensing_ChangeLicenseServer"								{$Results.Add("Change licensing server", "Licensing"); Break}
 			"Licensing_EditLicensingProperties"							{$Results.Add("Edit product edition", "Licensing"); Break}
 			"Licensing_Read"											{$Results.Add("View Licensing", "Licensing"); Break}
@@ -27036,9 +27898,12 @@ Function OutputControllers
 			FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
 		}
 		
-		$Script:ControllerRegistryItems = @()
-		GetControllerRegistryKeys $Controller.DNSName
-		OutputControllerRegistryKeys
+		If($BrokerRegistryKeys)
+		{
+			$Script:ControllerRegistryItems = @()
+			GetControllerRegistryKeys $Controller.DNSName
+			OutputControllerRegistryKeys
+		}
 	}
 
 	If($Hardware)
@@ -27424,34 +28289,108 @@ Function OutputControllerRegistryKeys
 	Write-Verbose "$(Get-Date): `t`t`tOutput Registry Key data"
 	$Script:ControllerRegistryItems = $Script:ControllerRegistryItems | Sort RegValue, RegKey
 	
-	If($Text)
+	$txt = "Controller Registry Items"
+	If($MSWord -or $PDF)
 	{
-		Line 0 "Controller Registry Items"
-		Line 1 "Registry Key                                                                  Registry Value                                     Data            " 
+		WriteWordLine 2 0 $txt
+	}
+	ElseIf($Text)
+	{
+		Line 0 $txt
+		Line 1 "Registry Value                                     Registry Key                                                                  Data            " 
 		Line 1 "================================================================================================================================================="
+	}
+	ElseIf($HTML)
+	{
+		WriteHTMLLine 2 0 $txt
+	}
+
+	If($MSWord -or $PDF)
+	{
+		[System.Collections.Hashtable[]] $WordTable = @();
+	}
+	ElseIf($HTML)
+	{
+		$rowdata = @()
 	}
 	
 	If($Script:ControllerRegistryItems)
 	{
 		ForEach($Item in $Script:ControllerRegistryItems)
 		{
-			If($Text)
+			If($MSWord -or $PDF)
 			{
-				Line 1 ( "{0,-77} {1,-50} {2,-15}" -f $Item.RegKey, $Item.RegValue, $Item.Value)
+				$WordTableRowHash = @{
+				RegValue = $Item.RegValue; 
+				RegKey = $Item.RegKey; 
+				Value = $Item.Value
+				}
+				$WordTable += $WordTableRowHash;
+			}
+			ElseIf($Text)
+			{
+				Line 1 ( "{0,-50} {1,-77} {2,-15}" -f $Item.RegValue, $Item.RegKey, $Item.Value)
+			}
+			ElseIf($HTML)
+			{
+				$rowdata += @(,(
+				$Item.RegValue,$htmlwhite,
+				$Item.RegKey,$htmlwhite,
+				$Item.Value,$htmlwhite))
 			}
 		}
 	}
 	Else
 	{
-		If($Text)
+		If($MSWord -or $PDF)
+		{
+			WriteWordLine 0 1 "<None found>"
+		}
+		ElseIf($Text)
 		{
 			Line 1 "<None found>"
 		}
+		ElseIf($HTML)
+		{
+			WriteHTMLLine 0 1 "None found"
+		}
 	}
 
-	If($Text)
+	If($MSWord -or $PDF)
+	{
+		$Table = AddWordTable -Hashtable $WordTable `
+		-Columns  RegValue, RegKey, Value `
+		-Headers  "Registry Value", "Registry Key", "Value" `
+		-Format $wdTableGrid `
+		-AutoFit $wdAutoFitFixed;
+
+		SetWordCellFormat -Collection $Table -Size 9
+		SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 210;
+		$Table.Columns.Item(2).Width = 230;
+		$Table.Columns.Item(3).Width = 60;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+		FindWordDocumentEnd
+		$Table = $Null
+	}
+	ElseIf($Text)
 	{
 		Line 0 ""
+	}
+	ElseIf($HTML)
+	{
+		$columnHeaders = @(
+		'Registry Value',($htmlsilver -bor $htmlbold),
+		'Registry Key',($htmlsilver -bor $htmlbold),
+		'Value',($htmlsilver -bor $htmlbold)
+		)
+
+		$msg = ""
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders
+		WriteHTMLLine 0 0 " "
 	}
 }
 #endregion
@@ -29960,75 +30899,77 @@ Function ProcessScriptEnd
 	{
 		$SIFile = "$($pwd.Path)\XAXDV2InventoryScriptInfo_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 		Out-File -FilePath $SIFile -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Add DateTime    : $($AddDateTime)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "AdminAddress    : $($AdminAddress)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Administrators  : $($Administrators)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Applications    : $($Applications)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Add DateTime       : $($AddDateTime)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "AdminAddress       : $($AdminAddress)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Administrators     : $($Administrators)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Applications       : $($Applications)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "BrokerRegistryKeys : $($BrokerRegistryKeys)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Company Name    : $($Script:CoName)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Company Address : $($CompanyAddress)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Company Email   : $($CompanyEmail)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Company Fax     : $($CompanyFax)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Company Phone   : $($CompanyPhone)" 4>$Null		
-			Out-File -FilePath $SIFile -Append -InputObject "Cover Page      : $($CoverPage)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Company Name       : $($Script:CoName)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Address    : $($CompanyAddress)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Email      : $($CompanyEmail)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Fax        : $($CompanyFax)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Company Phone      : $($CompanyPhone)" 4>$Null		
+			Out-File -FilePath $SIFile -Append -InputObject "Cover Page         : $($CoverPage)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "DeliveryGroups  : $($DeliveryGroups)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Dev             : $($Dev)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "DeliveryGroups     : $($DeliveryGroups)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Dev                : $($Dev)" 4>$Null
 		If($Dev)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "DevErrorFile    : $($Script:DevErrorFile)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "DevErrorFile       : $($Script:DevErrorFile)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "DGUtilization   : $($DeliveryGroupsUtilization)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Filename1       : $($Script:FileName1)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "DGUtilization      : $($DeliveryGroupsUtilization)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Filename1          : $($Script:FileName1)" 4>$Null
 		If($PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Filename2       : $($Script:FileName2)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Filename2          : $($Script:FileName2)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "Folder          : $($Folder)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "From            : $($From)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Hosting         : $($Hosting)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "HW Inventory    : $($Hardware)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Logging         : $($Logging)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Folder             : $($Folder)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "From               : $($From)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Hosting            : $($Hosting)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "HW Inventory       : $($Hardware)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Logging            : $($Logging)" 4>$Null
 		If($Logging)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "   Start Date    : $($StartDate)" 4>$Null
-			Out-File -FilePath $SIFile -Append -InputObject "   End Date      : $($EndDate)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "   Start Date      : $($StartDate)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "   End Date        : $($EndDate)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "MachineCatalogs : $($MachineCatalogs)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "NoADPolicies    : $($NoADPolicies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "NoPolicies      : $($NoPolicies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Policies        : $($Policies)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As HTML    : $($HTML)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As PDF     : $($PDF)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As TEXT    : $($TEXT)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Save As WORD    : $($MSWORD)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Script Info     : $($ScriptInfo)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Section         : $($Section)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Site Name       : $($XDSiteName)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Smtp Port       : $($SmtpPort)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Smtp Server     : $($SmtpServer)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Title           : $($Script:Title)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "To              : $($To)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Use SSL         : $($UseSSL)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "MachineCatalogs    : $($MachineCatalogs)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "MaxDetail          : $($MaxDetail)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "NoADPolicies       : $($NoADPolicies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "NoPolicies         : $($NoPolicies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Policies           : $($Policies)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As HTML       : $($HTML)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As PDF        : $($PDF)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As TEXT       : $($TEXT)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Save As WORD       : $($MSWORD)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Script Info        : $($ScriptInfo)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Section            : $($Section)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Site Name          : $($XDSiteName)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Smtp Port          : $($SmtpPort)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Smtp Server        : $($SmtpServer)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Title              : $($Script:Title)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "To                 : $($To)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Use SSL            : $($UseSSL)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "User Name       : $($UserName)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "User Name          : $($UserName)" 4>$Null
 		}
-		Out-File -FilePath $SIFile -Append -InputObject "XA/XD Version   : $($Script:XDSiteVersion)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "XA/XD Version      : $($Script:XDSiteVersion)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "OS Detected     : $($Script:RunningOS)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PoSH version    : $($Host.Version)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PSCulture       : $($PSCulture)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "PSUICulture     : $($PSUICulture)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "OS Detected        : $($Script:RunningOS)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PoSH version       : $($Host.Version)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PSCulture          : $($PSCulture)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "PSUICulture        : $($PSUICulture)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "Word language   : $($Script:WordLanguageValue)" 4>$Null
-			Out-File -FilePath $SIFile -Append -InputObject "Word version    : $($Script:WordProduct)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Word language      : $($Script:WordLanguageValue)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Word version       : $($Script:WordProduct)" 4>$Null
 		}
 		Out-File -FilePath $SIFile -Append -InputObject "" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Script start    : $($Script:StartTime)" 4>$Null
-		Out-File -FilePath $SIFile -Append -InputObject "Elapsed time    : $($Str)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Script start       : $($Script:StartTime)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Elapsed time       : $($Str)" 4>$Null
 	}
 
 	$ErrorActionPreference = $SaveEAPreference

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -31086,8 +31086,11 @@ Function ProcessScriptSetup
 		[int]$MajorVersion = $tmp[0]
 		[int]$MinorVersion = $tmp[1]
 	}
-
-	Write-Verbose "$(Get-Date): Found the version information on $($env:ComputerName)"
+	Else
+	{
+		Write-Verbose "$(Get-Date): Found the version information on $($env:ComputerName)"
+	}
+	
 	$value = $subKey.GetValue("DisplayVersion")
 	$Script:XDSiteVersion = $value.Substring(0,4)
 	$tmp = $Script:XDSiteVersion.Split(".")

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,17 +1,17 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}
-{\f39\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f40\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f42\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f41\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f42\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f44\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f45\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f46\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f47\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f48\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f49\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f61\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f62\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f64\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f65\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f66\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f67\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f68\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f69\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f431\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f432\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}
-{\f434\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f435\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f436\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f437\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}
-{\f438\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f439\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f441\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f442\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}
-{\f444\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f445\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f448\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f449\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f43\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f44\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f46\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f47\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f48\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f49\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f50\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f51\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f63\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f64\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
+{\f66\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f67\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f68\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f69\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
+{\f70\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f71\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f413\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f414\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}
+{\f416\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f417\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f418\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f419\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}
+{\f420\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f421\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f463\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f464\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}
+{\f466\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f467\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f470\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f471\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}
 {\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
 {\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
 {\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
@@ -36,16 +36,16 @@
 \red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;
 \red192\green192\blue192;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\f40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\f40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 
-\ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
+\fs24\lang1033\langfe1033\loch\f42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\f42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 
+\ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
 \ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\f40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
+\fs24\lang1033\langfe1033\loch\f42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf17 \sbasedon10 \styrsid16597410 FollowedHyperlink;}{\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext20 \sqformat \spriority1 \styrsid8394203 No Spacing;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext20 \sqformat \spriority1 \styrsid8394203 No Spacing;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel
 \levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
 \leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
 \levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
@@ -73,218 +73,219 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid677819\rsid928241\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3430394\rsid3761251\rsid3830441\rsid4149699\rsid4357927
-\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12602409\rsid12801149\rsid12863195\rsid13853169
-\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440
-\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo3\dy6\hr10\min1}{\version25}{\edmins11701}{\nofpages24}{\nofwords7335}{\nofchars41812}{\nofcharsws49049}{\vern19}}{\*\xmlnstbl {\xmlns1 http://schemas.micro
-soft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12353294\rsid12602409\rsid12801149
+\rsid12863195\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo6\dy16\hr20\min51}{\version26}{\edmins11720}{\nofpages28}{\nofwords8379}{\nofchars47765}{\nofcharsws56032}{\vern37}}
+{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBUa1AHgB0kcsAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBca1ADkwyV4sAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af40\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af40\dbch\af31505\loch\f40 Xen}{\rtlch\fcs1 \ab\af40\afs28 \ltrch\fcs0 
-\b\fs28\cf18\insrsid16517051 \hich\af40\dbch\af31505\loch\f40 Desktop 7.x}{\rtlch\fcs1 \ab\af40\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af40\dbch\af31505\loch\f40  Version }{\rtlch\fcs1 \ab\af40\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid928241 
-\hich\af40\dbch\af31505\loch\f40 2}{\rtlch\fcs1 \ab\af40\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af40\dbch\af31505\loch\f40  Documentation Script ReadMe
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \ab\af39\afs28 \ltrch\fcs0 \b\f39\fs28\insrsid11488686 
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5267713 {\rtlch\fcs1 \ab\af39 \ltrch\fcs0 \b\f39\insrsid5267713 \hich\af39\dbch\af31505\loch\f39 NOTE: This script requires PowerShell V3 or later.
+\fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af42\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af42\dbch\af31505\loch\f42 Xen}{\rtlch\fcs1 \ab\af42\afs28 \ltrch\fcs0 
+\b\fs28\cf18\insrsid16517051 \hich\af42\dbch\af31505\loch\f42 Desktop 7.x}{\rtlch\fcs1 \ab\af42\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af42\dbch\af31505\loch\f42  Version }{\rtlch\fcs1 \ab\af42\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid928241 
+\hich\af42\dbch\af31505\loch\f42 2}{\rtlch\fcs1 \ab\af42\afs28 \ltrch\fcs0 \b\fs28\cf18\insrsid11488686 \hich\af42\dbch\af31505\loch\f42  Documentation Script ReadMe
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5267713 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: This script requires PowerShell V3 or later.
 
-\par }{\rtlch\fcs1 \ab\af39 \ltrch\fcs0 \b\f39\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 NOTE: Best performance is obtained by using PowerShell V5.
-\par }{\rtlch\fcs1 \ab\af39 \ltrch\fcs0 \b\f39\insrsid5267713 \hich\af39\dbch\af31505\loch\f39 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af39 \ltrch\fcs0 \b\f39\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 t}{\rtlch\fcs1 \ab\af39 \ltrch\fcs0 
-\b\f39\insrsid5267713 \hich\af39\dbch\af31505\loch\f39  supported.}{\rtlch\fcs1 \ab\af39 \ltrch\fcs0 \b\f39\insrsid4357927 \hich\af39\dbch\af31505\loch\f39  }{\rtlch\fcs1 \af39 \ltrch\fcs0 \f39\insrsid5267713 
+\par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 NOTE: Best performance is obtained by using PowerShell V5.
+\par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 
+\b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37  supported.}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid4357927 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37 \ltrch\fcs0 \f37\insrsid5267713 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af40\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid11488686 \hich\af40\dbch\af31505\loch\f40 Support for non-English Versions of Microsoft Word
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 The \hich\af39\dbch\af31505\loch\f39 script supports the following languages:
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af39\afs22 
-\ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 Catalan}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid8662784 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid8662784 \hich\af39\dbch\af31505\loch\f39 Chinese}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid8662784\charrsid13987238 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 
-\hich\af39\dbch\af31505\loch\f39 Danish
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Dutch
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 English
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Finnish
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 French
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 German
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Norwegian
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Portuguese
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Spanish
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af39\dbch\af31505\loch\f39 Swedish
+\fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af42\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid11488686 \hich\af42\dbch\af31505\loch\f42 Support for non-English Versions of Microsoft Word
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The \hich\af37\dbch\af31505\loch\f37 script supports the following languages:
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Catalan}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid8662784 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8662784 \hich\af37\dbch\af31505\loch\f37 Chinese}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8662784\charrsid13987238 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 Danish
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Dutch
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 English
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Finnish
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 French
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 German
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Norwegian
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Portuguese
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Spanish
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Swedish
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af40\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid9112866 
-\hich\af40\dbch\af31505\loch\f40 Prerequisites
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39 Before we can start using PowerShell to document anything in a XenDesktop 7.x Site, let us ensure we have the necessary requirements.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid677819 \hich\af39\dbch\af31505\loch\f39 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af39\afs22 
-\ltrch\fcs0 \f39\fs22\insrsid677819 \hich\af39\dbch\af31505\loch\f39 If the script will be run remotely, }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 there are two choices: install }{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid677819 \hich\af39\dbch\af31505\loch\f39 Citrix Studio }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 or\hich\af39\dbch\af31505\loch\f39 
- manually install the PowerShell snapins.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid6258287\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 Install Studio from the full XenDesktop 7.x installation media. }{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid677819 \hich\af39\dbch\af31505\loch\f39 Installing Citrix Studio will install all the necessary PowerShell snapins.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 b.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 \hich\af39\dbch\af31505\loch\f39 
-Install the PowerShell snapins individually.}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Depending on the bitnes\hich\af39\dbch\af31505\loch\f39 
-s of the computer, from the full XenDesktop 7.x installation media, install the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6258287 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\ADIdentity_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 ii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\\hich\af39\dbch\af31505\loch\f39 Analytics_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 iii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\
+\fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af42\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid9112866 
+\hich\af42\dbch\af31505\loch\f42 Prerequisites
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a\hich\af37\dbch\af31505\loch\f37 
+ XenDesktop 7.x Site, let us ensure we have the necessary requirements.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 If the script will be run remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 there are two choices: install }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Citrix Studio }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 or manually install the PowerShell snapins.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid6258287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 Install Studio from the full XenDesktop 7.x installation media. }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Installing Citrix Studio will install all the necessary PowerShell snapins.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 
+Install the PowerShell snapins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Depending on the bitness of the computer, from the full XenDesktop 7\hich\af37\dbch\af31505\loch\f37 
+.x installation media, install the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ADIdentity_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Analytics_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\
 AppLibrary_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 iv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 v.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\Configuration_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 vi.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citri
-\hich\af39\dbch\af31505\loch\f39 x}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 vii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\Del}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 egatedAdmin_PowerShellSnapIn_x??}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 viii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 \hich\af39\dbch\af31505\loch\f39  Desktop Delivery Controller\\}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 EnvTest_PowerShell_SnapIn_x??}{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid3761251 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 ix.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controll\hich\af39\dbch\af31505\loch\f39 er\\
-Host_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 x.\tab}\hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\MachineCreation_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 xi.\tab}\hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\Monitor_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 xii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 v.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configuration_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configu\hich\af37\dbch\af31505\loch\f37 rationLogging_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Del}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 egatedAdmin_PowerShellSnapIn_x??}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 viii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 EnvTest_PowerShell_SnapIn_x??}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Host_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 x.\tab}\hich\af37\dbch\af31505\loch\f37 Citr\hich\af37\dbch\af31505\loch\f37 ix Desktop Delivery Controller\\
+MachineCreation_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xi.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Monitor_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 xii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\
 Orchestration_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 xiii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Ci\hich\af39\dbch\af31505\loch\f39 trix Desktop Delivery Controller\\
-Storefront_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 xiv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\Trust_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Stor
+\hich\af37\dbch\af31505\loch\f37 efront_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 xiv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Trust_PowerShellSnapIn_x??
 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 xv.\tab}\hich\af39\dbch\af31505\loch\f39 Citrix Desktop Delivery Controller\\UserProfileManager_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid12602409 \hich\af39\dbch\af31505\loch\f39 xvi.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid12602409 \hich\af39\dbch\af31505\loch\f39 
-7.13 and later: Citrix Desktop Delivery \hich\af39\dbch\af31505\loch\f39 Controller\\XDPoshSnapin_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 xvii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 Citrix Policy\\CitrixGroupPolicyManagement_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 xviii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 DesktopStudio\\
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 xv.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\UserProfileManager_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12602409 \hich\af37\dbch\af31505\loch\f37 xvi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12602409 \hich\af37\dbch\af31505\loch\f37 
+7.13 and later: Citrix Desktop Delivery Controller\\XDPoshSnapin_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xvii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Cit\hich\af37\dbch\af31505\loch\f37 rix Policy\\
+CitrixGroupPolicyManagement_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 xviii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\
 PVS PowerShell SDK x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 xix.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid6316284 \hich\af39\dbch\af31505\loch\f39 DesktopStudio\\Pz}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 AppV_Studio_PowershellSnapin_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid219208 \hich\af39\dbch\af31505\loch\f39 xx.\tab}\hich\af39\dbch\af31505\loch\f39 Licensing\\LicensingAdmin_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 2.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 Install the Citrix Group Policy PowerShell module.}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39  There are two options, download the module or copy the file from a Controller.}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 Download the file:
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 In your Internet browser; go to }
-{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39  HYPERLINK "https:/\hich\af39\dbch\af31505\loch\f39 
-/dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 {\*\datafield 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 xix.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\Pz}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 AppV_Studio_PowershellSnapin_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xx.\tab}\hich\af37\dbch\af31505\loch\f37 Licensing\\LicensingAdmin_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Install the Citrix Group Policy PowerShell module.}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  There are two options, download the module or copy the file from a Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 Download the file:
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }
+{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb2000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff}}}{\fldrslt {
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \cs18\f39\fs22\ul\cf2\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 https://dl.dropboxuserconten\hich\af39\dbch\af31505\loch\f39 t.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 ii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 
-\hich\af39\dbch\af31505\loch\f39 Save the file to your default download folder.}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 iii.\tab}}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 
-\hich\af39\dbch\af31505\loch\f39 Extract the file to }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 C:\\X}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866 
-\hich\af39\dbch\af31505\loch\f39 D7Script}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 iv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid14881286\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 Close your Internet browser.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 b.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 Copy the file from a Controller:
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 On a 32-bit Controller, go to %PROGRAMFILES%\\Citrix\\Scout\\
+3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff22}}}{\fldrslt {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 Save the file to your default download fol\hich\af37\dbch\af31505\loch\f37 der.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 C:\\X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866 
+\hich\af37\dbch\af31505\loch\f37 D7Script}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid14881286\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Close your Internet browser.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 b.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 Copy the file from a Controller:
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 On a 32-bit Controller, go to %PROGRAMFILES%\\Citrix\\Scout\\
 Current\\Utilities
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 ii.\tab}\hich\af39\dbch\af31505\loch\f39 On a 64-bit Controller, go to %PROGRAMFILES(x86)%\\Citrix\\Scout\\Current\\Utilities
-
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 
-If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af40\dbch\af31505\loch\f40  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid12801149 
-\hich\af39\dbch\af31505\loch\f39 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 to }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 
-\i\f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 
-, in a new folder named }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid12801149 \hich\af39\dbch\af31505\loch\f39 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 
-\hich\af39\dbch\af31505\loch\f39 . This should be placed on the computer where the script is run.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 If you are running 64-bit Windows, }{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af40\dbch\af31505\loch\f40  }{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 to
-\hich\af39\dbch\af31505\loch\f39  }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 , in a new folder named }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 Citrix.GroupPolicy.Commands}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid16597410 \hich\af39\dbch\af31505\loch\f39 . This should be placed on the computer where the script is run.
-\par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\par }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39 Note:}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39  The Citrix.GroupPolicy.Commands.psm1 file is }{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \b\f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39 not}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39  the version that comes with 
-\hich\af39\dbch\af31505\loch\f39 XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16207041 \hich\af39\dbch\af31505\loch\f39 installed with XenDesktop 7.x or }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 {\*\datafield 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 ii.\tab}\hich\af37\dbch\af31505\loch\f37 On a 64-bit Controller, go to %PROGRAMFILES(x86)%\\Citrix\\
+\hich\af37\dbch\af31505\loch\f37 Scout\\Current\\Utilities
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
+If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af42\dbch\af31505\loch\f42  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
+, in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 . This should be placed on the co\hich\af37\dbch\af31505\loch\f37 mputer where the script is run.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are running 64-bit Windows, }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af42\dbch\af31505\loch\f42  }{\rtlch\fcs1 \af0\afs22 
+\ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 
+\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 
+\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  The Citrix.GroupPolicy.Commands.psm1 file is }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+ the version that comes with XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16207041 \hich\af37\dbch\af31505\loch\f37 installed with XenDesktop 7.x or }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000}}}{\fldrslt {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \cs18\f39\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af39\dbch\af31505\loch\f39 Citrix Scout}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39 .  The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 ,}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39  the updated version is from Ju}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9986361 \hich\af39\dbch\af31505\loch\f39 ne}{\rtlch\fcs1 \af39\afs22 
-\ltrch\fcs0 \f39\fs22\insrsid9112866 \hich\af39\dbch\af31505\loch\f39  2014}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9986361 \hich\af39\dbch\af31505\loch\f39 . }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866 
-\hich\af39\dbch\af31505\loch\f39 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16597410 \hich\af39\dbch\af31505\loch\f39 
- You cannot use the updated version to run against a remote\hich\af39\dbch\af31505\loch\f39  XenApp 6.5 Collector.}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid9112866\charrsid12801149 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe0000002200300000000000000064}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 .  The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated v\hich\af37\dbch\af31505\loch\f37 ersion is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 
+ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
+ You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af40\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid16597410 \hich\af40\dbch\af31505\loch\f40 
+\fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af42\afs26 \ltrch\fcs0 \b\fs26\cf19\insrsid16597410 \hich\af42\dbch\af31505\loch\f42 
 Script Usage
-\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid11488686 \hich\af40\dbch\af31505\loch\f40 How to use this script?
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af39\afs22 
-\ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 Save the script as }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 X}{\rtlch\fcs1 
-\ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 D7}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 _Inventory}{\rtlch\fcs1 \ai\af39\afs22 
-\ltrch\fcs0 \i\f39\fs22\insrsid8876191 \hich\af39\dbch\af31505\loch\f39 _V2}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 .ps1 }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 in your PowerShell scripts folder.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 2.\tab}\hich\af39\dbch\af31505\loch\f39 From the PowerShell prompt, change to your PowerShell scripts}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid13853169 \hich\af39\dbch\af31505\loch\f39  folder}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 3.\tab}\hich\af39\dbch\af31505\loch\f39 From the PowerShell prompt, type in:
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 .\\\hich\af39\dbch\af31505\loch\f39 X}{\rtlch\fcs1 \ai\af39\afs22 
-\ltrch\fcs0 \i\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 D7}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 _Inventory}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 
-\i\f39\fs22\insrsid8876191 \hich\af39\dbch\af31505\loch\f39 _V2}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 .ps1 }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 and press }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 Enter}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid11488686\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 
-By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Desktop 7.x Site}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid11488686\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 5.\tab}\hich\af39\dbch\af31505\loch\f39 If you use the \hich\f39 \endash \loch\f39 
-PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Desktop 7.x Site}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686\charrsid13987238 .}{
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid16517051\contextualspace {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 If you use the \hich\f39 \endash }{\rtlch\fcs1 
-\af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 HTML}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39  option, a}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 n HTML}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39  file is created named after the Xen}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Desktop 7.x Site}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 7.\tab}\hich\af39\dbch\af31505\loch\f39 If you use the \hich\f39 \endash }{\rtlch\fcs1 \af39\afs22 
-\ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Text}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39  option, a }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Text}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39  file is created named after the Xen}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 Desktop 7.x Site}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 .}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid16517051 
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 To }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 run}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39  the script }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 against a remote Controller:
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
+\ltrch\fcs0 \insrsid11488686 \hich\af42\dbch\af31505\loch\f42 How to use this script?
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 
+\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \ai\af37\afs22 
+\ltrch\fcs0 \i\f37\fs22\insrsid8876191 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13853169 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 .\\\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \ai\af37\afs22 
+\ltrch\fcs0 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid8876191 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11488686\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, a Microsoft Word document is cre
+\hich\af37\dbch\af31505\loch\f37 ated named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
+PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid16517051\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 n HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid16517051 
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 To }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 run}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37  the script }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 against a remote Controller:
 \par }\pard\plain \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid16517051\charrsid13987238 .\\\hich\af39\dbch\af31505\loch\f39 X}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 
-\i\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 D7}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 _Inventory}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 
-\i\f39\fs22\insrsid8876191 \hich\af39\dbch\af31505\loch\f39 _V2}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 .ps1}{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 \i\f39\fs22\insrsid16517051 
-\hich\af39\dbch\af31505\loch\f39 -AdminAddress DDCName }{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 and press }{\rtlch\fcs1 \ai\af39\afs22 \ltrch\fcs0 
-\i\f39\fs22\insrsid16517051\charrsid13987238 \hich\af39\dbch\af31505\loch\f39 Ent\hich\af39\dbch\af31505\loch\f39 er}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid16517051\charrsid13987238 .
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 Full help text is available.
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 Get-Help .\\X}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 
-\f39\fs22\insrsid16517051 \hich\af39\dbch\af31505\loch\f39 D7}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 _Inventory}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid8876191 
-\hich\af39\dbch\af31505\loch\f39 _V2}{\rtlch\fcs1 \af39\afs22 \ltrch\fcs0 \f39\fs22\insrsid11488686 \hich\af39\dbch\af31505\loch\f39 .ps1 \hich\f39 \endash \loch\f39 full
+\fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 .\\\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid8876191 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 
+\hich\af37\dbch\af31505\loch\f37 -AdminAddress DDCName }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8876191 
+\hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par 
-\par \hich\af39\dbch\af31505\loch\f39 The help text explains all the parameters the script accepts.
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af40\dbch\af31505\loch\f40 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
-\par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\par \hich\af37\dbch\af31505\loch\f37 The help te\hich\af37\dbch\af31505\loch\f37 xt explains all the parameters the script accepts.
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af42\dbch\af31505\loch\f42 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
+\par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8876191 
-\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15678052 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\
+\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7763859 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7763859\charrsid7763859 \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\
 XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
@@ -295,78 +296,50 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-MSWord] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-Poli\hich\af2\dbch\af31505\loch\f2 cies] [-NoPolicies] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-StoreFront] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] [-Use\hich\af2\dbch\af31505\loch\f2 rName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [-MSWord] [-Ad\hich\af2\dbch\af31505\loch\f2 ministrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups]
+\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>]
+\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPoli\hich\af2\dbch\af31505\loch\f2 cies] [-StoreFront] [-AddDateTime] [-Folder
+\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-MSWord] [-PDF] [-Text] [-HTML] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] [-MachineCatalogs]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Applications] [\hich\af2\dbch\af31505\loch\f2 -Policies] [-NoPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-Logging] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-StoreFront] [-StartDate <DateTime>] [-EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Folder <String>] [-CompanyName <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] \hich\af2\dbch\af31505\loch\f2 [-UserName <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] -From }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String> -To <String>}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [-HTML] [-MSWord] [-PDF] [-Text] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys]
+\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroups] [-DeliveryGrou\hich\af2\dbch\af31505\loch\f2 psUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>]
+\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder
+\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] -SmtpServe\hich\af2\dbch\af31505\loch\f2 r <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To
+\par \hich\af2\dbch\af31505\loch\f2     <String> [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-PDF] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Deli\hich\af2\dbch\af31505\loch\f2 veryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-Policies] [-NoPolicies] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-StoreFront] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <Stri\hich\af2\dbch\af31505\loch\f2 ng>] [-Folder <String>] [-CompanyName <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <Str\hich\af2\dbch\af31505\loch\f2 ing>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [-PDF] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups]
+\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-Star\hich\af2\dbch\af31505\loch\f2 tDate <DateTime>] [-EndDate <DateTime>]
+\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder
+\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-Text] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGrou\hich\af2\dbch\af31505\loch\f2 ps] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-Policies] [-NoPolicies] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-StoreFront] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Folder <Strin\hich\af2\dbch\af31505\loch\f2 g>] [-Dev] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] [-AppDisks]
+\par \hich\af2\dbch\af31505\loch\f2     [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging]
+\par \hich\af2\dbch\af31505\loch\f2     [-StartDate <DateTime>] [-EndDate <D\hich\af2\dbch\af31505\loch\f2 ateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies]
+\par \hich\af2\dbch\af31505\loch\f2     [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev]
+\par \hich\af2\dbch\af31505\loch\f2     [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-HTML] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-Policies] [-NoPolicies] [-NoADPolic\hich\af2\dbch\af31505\loch\f2 ies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-StoreFront] [-StartDate <DateTime>] [-EndDate <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Folder <String>] [-Dev] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps\hich\af2\dbch\af31505\loch\f2 1 [-AdminAddress <String>] [-Text] [-Administrators] [-AppDisks]
+\par \hich\af2\dbch\af31505\loch\f2     [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging]
+\par \hich\af2\dbch\af31505\loch\f2     [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetail\hich\af2\dbch\af31505\loch\f2 s] [-Policies] [-NoPolicies]
+\par \hich\af2\dbch\af31505\loch\f2     [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev]
+\par \hich\af2\dbch\af31505\loch\f2     [-ScriptInfo] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site using Microsoft PowerShell, Word,
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site using Mic\hich\af2\dbch\af31505\loch\f2 rosoft PowerShell, Word,
 \par \hich\af2\dbch\af31505\loch\f2     plain text or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This Script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script w\hich\af2\dbch\af31505\loch\f2 ill output in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this scrip\hich\af2\dbch\af31505\loch\f2 t on a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
@@ -374,18 +347,18 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop starting with 7.8.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
-\par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         AppDisks
-\par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
-\par \hich\af2\dbch\af31505\loch\f2         Applications
-\par \hich\af2\dbch\af31505\loch\f2         Application Groups
-\par \hich\af2\dbch\af31505\loch\f2         Policie\hich\af2\dbch\af31505\loch\f2 s
-\par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
-\par \hich\af2\dbch\af31505\loch\f2         Hosting
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
+\par \hich\af2\dbch\af31505\loch\f2         AppDisks
 \par \hich\af2\dbch\af31505\loch\f2         AppDNA
+\par \hich\af2\dbch\af31505\loch\f2         Application Groups
+\par \hich\af2\dbch\af31505\loch\f2         Applications
+\par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Hosting
+\par \hich\af2\dbch\af31505\loch\f2         Logging
+\par \hich\af2\dbch\af31505\loch\f2         Machine Cata\hich\af2\dbch\af31505\loch\f2 logs
+\par \hich\af2\dbch\af31505\loch\f2         Policies
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
@@ -394,27 +367,24 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2         Logging
+\par \hich\af2\dbch\af31505\loch\f2         Loggi\hich\af2\dbch\af31505\loch\f2 ng
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     c}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     c}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters c\hich\af2\dbch\af31505\loch\f2 an cause the report to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 take an}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely \hich\af2\dbch\af31505\loch\f2 long time to complete and generate an exceptionally long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following langua\hich\af2\dbch\af31505\loch\f2 ge versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -426,10 +396,184 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
+\par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <S\hich\af2\dbch\af31505\loch\f2 tring>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect
+\par \hich\af2\dbch\af31505\loch\f2         to.
+\par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             ViewMaster (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
+\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manuall\hich\af2\dbch\af31505\loch\f2 y changed to
+\par \hich\af2\dbch\af31505\loch\f2                 36 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't f\hich\af2\dbch\af31505\loch\f2 it; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 20\hich\af2\dbch\af31505\loch\f2 16, works in
+\par \hich\af2\dbch\af31505\loch\f2                 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless \hich\af2\dbch\af31505\loch\f2 changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only val\hich\af2\dbch\af31505\loch\f2 id with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard chara\hich\af2\dbch\af31505\loch\f2 cters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value  \hich\af2\dbch\af31505\loch\f2               False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
@@ -441,191 +585,26 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word Save\hich\af2\dbch\af31505\loch\f2 As PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 to.
-\par \hich\af2\dbch\af31505\loch\f2         This can be provided as\hich\af2\dbch\af31505\loch\f2  a host name or an IP address.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to t\hich\af2\dbch\af31505\loch\f2 ake an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?              \hich\af2\dbch\af31505\loch\f2       named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AppDisks [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all AppDisks.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AD.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long repor\hich\af2\dbch\af31505\loch\f2 t.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
-\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This opti\hich\af2\dbch\af31505\loch\f2 on is only available when the report is generated in Word and requires
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 time to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 complete and generates a longer report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                \hich\af2\dbch\af31505\loch\f2 False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r has an alias of Apps.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Policies [\hich\af2\dbch\af31505\loch\f2 <SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
-\par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The\hich\af2\dbch\af31505\loch\f2 re are three related parameters: Policies, NoPolicies and NoADPolicies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Excludes all Site and Citrix AD-based policy information from the output document.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of NP.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<S\hich\af2\dbch\af31505\loch\f2 witchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 seven days.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Log.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
@@ -637,31 +616,106 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Give detailed information for Hosts, Host Connections, and Resources.
+\par \hich\af2\dbch\af31505\loch\f2     -AppDisks [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all AppDisks.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
+\par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
+\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
+\par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   For Text and HTML, this adds 315 lines, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause\hich\af2\dbch\af31505\loch\f2  the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate a\hich\af2\dbch\af31505\loch\f2 n exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 da\hich\af2\dbch\af31505\loch\f2 ys
+\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes\hich\af2\dbch\af31505\loch\f2  the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections, and Resources.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
+\par \hich\af2\dbch\af31505\loch\f2         seven days.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter has an alias of Log.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Star\hich\af2\dbch\af31505\loch\f2 tDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
@@ -674,7 +728,7 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     ((Get-Date -displayhint date).AddDays(-7))
+\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDa\hich\af2\dbch\af31505\loch\f2 ys(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -683,45 +737,159 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific\hich\af2\dbch\af31505\loch\f2  time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fals\hich\af2\dbch\af31505\loch\f2 e
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2017-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
+\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in a\hich\af2\dbch\af31505\loch\f2 ll Machine Catalogs.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MaxDeta\hich\af2\dbch\af31505\loch\f2 ils [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
+\par \hich\af2\dbch\af31505\loch\f2                 Administrators
+\par \hich\af2\dbch\af31505\loch\f2                 AppDisks
+\par \hich\af2\dbch\af31505\loch\f2                 Applications
+\par \hich\af2\dbch\af31505\loch\f2                 BrokerRegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2                 HardWare
+\par \hich\af2\dbch\af31505\loch\f2                 Hosting
+\par \hich\af2\dbch\af31505\loch\f2                 Logging
+\par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2                 Policies
+\par \hich\af2\dbch\af31505\loch\f2                 StoreFront
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using th\hich\af2\dbch\af31505\loch\f2 e Policies parameter can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutua\hich\af2\dbch\af31505\loch\f2 lly exclusive and priority is given to NoPolicies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD-based policy information from the output document.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output\hich\af2\dbch\af31505\loch\f2  document.
+\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the \hich\af2\dbch\af31505\loch\f2 end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2017 at 6PM is 2017-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2017-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter has an alias of ADT.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Network}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor and
+\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elev\hich\af2\dbch\af31505\loch\f2 ated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 or}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Local Administrator).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevate\hich\af2\dbch\af31505\loch\f2 d PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 ize}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of th\hich\af2\dbch\af31505\loch\f2 e report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
@@ -738,8 +906,7 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 AppDisks
 \par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              AppDNA
-\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11823514 \hich\af2\dbch\af31505\loch\f2  and Application Group Details}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
@@ -755,128 +922,27 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
-\par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         Using Loggin\hich\af2\dbch\af31505\loch\f2 g will force the Logging switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, the script will terminate.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the o\hich\af2\dbch\af31505\loch\f2 utput report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15678052 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name\hich\af2\dbch\af31505\loch\f2  to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 populated on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 computer runni\hich\af2\dbch\af31505\loch\f2 ng the script.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 report will}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and \hich\af2\dbch\af31505\loch\f2 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
-\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 works in 2010 but}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 Subtitle/Subject & Author fields need to be moved}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\kerning1\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\kerning1\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 manually resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\kerning1\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works if top date is manually changed to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Puzzle (Word 2010. Top date doesn't fit; box needs to be manually }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\kerning1\insrsid15678052\charrsid5209339 \hich\af2\dbch\af31505\loch\f2 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The defaul\hich\af2\dbch\af31505\loch\f2 t value is Sideline.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15678052 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af40\hich\af40\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $e\hich\af2\dbch\af31505\loch\f2 nv:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value             \hich\af2\dbch\af31505\loch\f2    $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the outp\hich\af2\dbch\af31505\loch\f2 ut report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Posit\hich\af2\dbch\af31505\loch\f2 ion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP p\hich\af2\dbch\af31505\loch\f2 ort.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -885,29 +951,29 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Spe\hich\af2\dbch\af31505\loch\f2 cifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2     -UseSS\hich\af2\dbch\af31505\loch\f2 L [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         true
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpSe\hich\af2\dbch\af31505\loch\f2 rver is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -915,24 +981,24 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the begi\hich\af2\dbch\af31505\loch\f2 nning of the script.
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is r\hich\af2\dbch\af31505\loch\f2 un.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
@@ -940,40 +1006,43 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about\hich\af2\dbch\af31505\loch\f2 _CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and \hich\af2\dbch\af31505\loch\f2 OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF
-\par \hich\af2\dbch\af31505\loch\f2     plain text or HTML document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
+\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     NAME: XD7_Inventory_V2.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12272355 \hich\af2\dbch\af31505\loch\f2         VERSION: 2.04}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.05
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12272355 \hich\af2\dbch\af31505\loch\f2 March 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 
-\hich\af2\dbch\af31505\loch\f2 , 2017
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: June 16, 2017
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -983,18 +1052,18 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\XD7_Inventory_V2.ps1 -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 ="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     DDC01 \hich\af2\dbch\af31505\loch\f2 for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1004,14 +1073,14 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compa\hich\af2\dbch\af31505\loch\f2 nyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the\hich\af2\dbch\af31505\loch\f2  User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1019,12 +1088,12 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -TEXT
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -T\hich\af2\dbch\af31505\loch\f2 EXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl\hich\af2\dbch\af31505\loch\f2  Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="\hich\af2\dbch\af31505\loch\f2 Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1036,12 +1105,12 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1057,8 +1126,8 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1073,10 +1142,10 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Grou\hich\af2\dbch\af31505\loch\f2 ps.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1089,18 +1158,18 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilizati\hich\af2\dbch\af31505\loch\f2 on
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 Name="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Us\hich\af2\dbch\af31505\loch\f2 er Name.
 \par 
 \par 
 \par 
@@ -1110,14 +1179,14 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
+\par \hich\af2\dbch\af31505\loch\f2     all deskt\hich\af2\dbch\af31505\loch\f2 ops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:u\hich\af2\dbch\af31505\loch\f2 sername = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1128,12 +1197,12 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for \hich\af2\dbch\af31505\loch\f2 all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username =\hich\af2\dbch\af31505\loch\f2  Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HK\hich\af2\dbch\af31505\loch\f2 EY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1142,18 +1211,18 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1164,10 +1233,10 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy informatio\hich\af2\dbch\af31505\loch\f2 n.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1178,15 +1247,15 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 13 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1198,15 +1267,15 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1218,15 +1287,15 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\X\hich\af2\dbch\af31505\loch\f2 D7_Inventory_V2.ps1 -Administrators
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Adm\hich\af2\dbch\af31505\loch\f2 inistrator Scopes and Roles.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1235,22 +1304,23 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 16 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017 -EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 01/31/2017
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate 01/31/2017
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/2017 through
-\par \hich\af2\dbch\af31505\loch\f2     01/31/2\hich\af2\dbch\af31505\loch\f2 017.
+\par \hich\af2\dbch\af31505\loch\f2     01/31/2017.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrat\hich\af2\dbch\af31505\loch\f2 or
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1258,21 +1328,22 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -\hich\af2\dbch\af31505\loch\f2 Logging -StartDate "06/01/2017 10:00:00" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -EndDate "06/01/2017 14:00:00"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate "06/01/2017 14:00:00\hich\af2\dbch\af31505\loch\f2 "
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
 \par \hich\af2\dbch\af31505\loch\f2     06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does\hich\af2\dbch\af31505\loch\f2  not work. Seconds must be either 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1281,13 +1352,13 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\X\hich\af2\dbch\af31505\loch\f2 D7_Inventory_V2.ps1 -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hosting
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections, and Resources.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a re\hich\af2\dbch\af31505\loch\f2 port with full details for Hosts, Host Connections, and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1297,29 +1368,29 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRE\hich\af2\dbch\af31505\loch\f2 NT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -Policies -Hosting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
@@ -1328,14 +1399,14 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Defaul\hich\af2\dbch\af31505\loch\f2 t values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microso\hich\af2\dbch\af31505\loch\f2 ft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the \hich\af2\dbch\af31505\loch\f2 Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page for\hich\af2\dbch\af31505\loch\f2 mat.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1345,20 +1416,20 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Crea\hich\af2\dbch\af31505\loch\f2 tes a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
+\par \hich\af2\dbch\af31505\loch\f2         Machine\hich\af2\dbch\af31505\loch\f2 s in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline \hich\af2\dbch\af31505\loch\f2 for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1366,9 +1437,9 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserNam\hich\af2\dbch\af31505\loch\f2 e}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 "Carl Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPag\hich\af2\dbch\af31505\loch\f2 e "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
@@ -1379,14 +1450,15 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------\hich\af2\dbch\af31505\loch\f2 ----------------- EXAMPLE 23 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (al\hich\af2\dbch\af31505\loch\f2 ias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
@@ -1395,38 +1467,74 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7\hich\af2\dbch\af31505\loch\f2 _Inventory_V2.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 >PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HH\hich\af2\dbch\af31505\loch\f2 mm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Su\hich\af2\dbch\af31505\loch\f2 perSleuth@SherlockHolmes.com for the Compnay Email.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_2017-06-01_1800.docx
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will us\hich\af2\dbch\af31505\loch\f2 e all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURR\hich\af2\dbch\af31505\loch\f2 ENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideli\hich\af2\dbch\af31505\loch\f2 ne for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
@@ -1437,34 +1545,34 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_\hich\af2\dbch\af31505\loch\f2 Inventory_V2.ps1 -Hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:\hich\af2\dbch\af31505\loch\f2 username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page \hich\af2\dbch\af31505\loch\f2 format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.p\hich\af2\dbch\af31505\loch\f2 s1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1473,107 +1581,102 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 28 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld -To ITGroup@domain.tld
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator f\hich\af2\dbch\af31505\loch\f2 or the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid11823514 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid15678052\charrsid15692337 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 sending to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credent\hich\af2\dbch\af31505\loch\f2 ials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 credentials.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com -To ITGroup@CarlWebster.com
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 58\hich\af2\dbch\af31505\loch\f2 7 using SSL, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     f}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 rom}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 credentials.
-\par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 30 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_\hich\af2\dbch\af31505\loch\f2 V2.ps1 -SmtpServer mail.domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webs\hich\af2\dbch\af31505\loch\f2 ter" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Proces\hich\af2\dbch\af31505\loch\f2 ses only the Policies section of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send e\hich\af2\dbch\af31505\loch\f2 mail,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@Car\hich\af2\dbch\af31505\loch\f2 lWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScr\hich\af2\dbch\af31505\loch\f2 ipt >.\\XD7_Inventory_V2.ps1 -Section Groups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15678052\charrsid15678052 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Web\hich\af2\dbch\af31505\loch\f2 ster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Proce\hich\af2\dbch\af31505\loch\f2 sses only the Delivery Groups section of the report with Delivery Group details.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1582,7 +1685,65 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 RE\hich\af2\dbch\af31505\loch\f2 LATED LINKS
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PS\hich\af2\dbch\af31505\loch\f2 Script >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="\hich\af2\dbch\af31505\loch\f2 Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on 315 Broker registry keys to the Controllers section.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 36 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MaxDetails
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Set the follo\hich\af2\dbch\af31505\loch\f2 wing parameter values:
+\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
+\par \hich\af2\dbch\af31505\loch\f2         AppDisks            = True
+\par \hich\af2\dbch\af31505\loch\f2         Applications        = True
+\par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
+\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
+\par \hich\af2\dbch\af31505\loch\f2         Hosting        \hich\af2\dbch\af31505\loch\f2      = True
+\par \hich\af2\dbch\af31505\loch\f2         Logging             = True
+\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
+\par \hich\af2\dbch\af31505\loch\f2         Policies            = True
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
+\par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
+\par 
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting>}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12353294\charrsid12353294 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -1635,7 +1796,7 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
 6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
 656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax374\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+{\*\latentstyles\lsdstimax375\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;
@@ -1692,7 +1853,8 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 \lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
 \lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e30000000000000000000000e0000
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;}}{\*\datastore 010500000200000018000000
+4d73786d6c322e534158584d4c5265616465722e362e30000000000000000000000e0000
 d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff0900060000000000000000000000010000000100000000000000001000000200000001000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1701,10 +1863,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000a051
-e7ec9296d20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000a051e7ec9296d201
-a051e7ec9296d201000000000000000000000000d700cf00d700410042003300550048004a004500d200c500c400480059004700db00cd00cc005300c10041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000a051e7ec9296
-d201a051e7ec9296d2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000504d
+a9460ce7d20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000504da9460ce7d201
+504da9460ce7d201000000000000000000000000c600cf00cf004d0045004a00d500c800c600d40034004400ce004500c900430030003000c100cf00dd00c0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000504da9460ce7
+d201504da9460ce7d2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1712,7 +1874,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b30354330464444452d303744352d344332342d413539302d3736303645454442313238347d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b31304343464239412d363839442d343739422d383342382d3441343236394138364646367d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f42\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f42\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f43\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f44\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -73,13 +73,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid346080\rsid677819\rsid928241\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3430394\rsid3761251\rsid3830441\rsid4149699
-\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12353294\rsid12602409
-\rsid12801149\rsid12863195\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1
-\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo6\dy24\hr12\min5}{\version27}{\edmins11727}{\nofpages26}{\nofwords8362}{\nofchars47666}{\nofcharsws55917}
-{\vern37}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6947370\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12353294
+\rsid12602409\rsid12801149\rsid12863195\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
+\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo6\dy25\hr13\min59}{\version28}{\edmins11727}{\nofpages26}{\nofwords8362}{\nofchars47666}
+{\nofcharsws55917}{\vern37}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBca1ADkwyV4sAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBSa1AP6miBEsAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -186,11 +186,11 @@ PVS PowerShell SDK x??
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb2000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff226b}}}{\fldrslt {
+3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff226b00}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
-\hich\af37\dbch\af31505\loch\f37 Save the file to your default download fol\hich\af37\dbch\af31505\loch\f37 der.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\hich\af37\dbch\af31505\loch\f37 Save the file to your default download fo\hich\af37\dbch\af31505\loch\f37 lder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 C:\\X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866 
 \hich\af37\dbch\af31505\loch\f37 D7Script}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
@@ -224,9 +224,9 @@ If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \lt
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe000000220030000000000000006400}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 .  The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated v\hich\af37\dbch\af31505\loch\f37 ersion is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated \hich\af37\dbch\af31505\loch\f37 version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 
 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
@@ -302,32 +302,32 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlc
 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Administra\hich\af2\dbch\af31505\loch\f2 tors] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Administrators] \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-Stor\hich\af2\dbch\af31505\loch\f2 eFront] [-AddDateTime] [-Folder <String>] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [\hich\af2\dbch\af31505\loch\f2 -StoreFront] [-AddDateTime] [-Folder <String>] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String\hich\af2\dbch\af31505\loch\f2 >] [-CompanyName <String>] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFa\hich\af2\dbch\af31505\loch\f2 x <String>] [-CompanyName <String>] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-Text] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting\hich\af2\dbch\af31505\loch\f2 ] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUt\hich\af2\dbch\af31505\loch\f2 ilization] [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] -SmtpServer <String> [-SmtpPort <Int32>] [\hich\af2\dbch\af31505\loch\f2 -UseSSL] 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] -SmtpSe\hich\af2\dbch\af31505\loch\f2 rver <String> [-SmtpPort <Int32>] [-UseSSL] 
 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [-Dev] [-ScriptInfo]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
@@ -336,37 +336,37 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlc
 XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Comp\hich\af2\dbch\af31505\loch\f2 anyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-Policies] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-Delive\hich\af2\dbch\af31505\loch\f2 ryGroupsUtilization]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String\hich\af2\dbch\af31505\loch\f2 >] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory_V2.ps1 [-AdminAddress <\hich\af2\dbch\af31505\loch\f2 String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicie\hich\af2\dbch\af31505\loch\f2 s] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies] [-StoreFront] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Log\hich\af2\dbch\af31505\loch\f2 
+ging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies] [-StoreFront] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParam\hich\af2\dbch\af31505\loch\f2 eters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-App\hich\af2\dbch\af31505\loch\f2 lications] [-BrokerRegistryKeys] [-DeliveryGroups] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDa\hich\af2\dbch\af31505\loch\f2 
+te }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid346080 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
@@ -381,19 +381,19 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and r\hich\af2\dbch\af31505\loch\f2 un
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminA\hich\af2\dbch\af31505\loch\f2 ddress (AA) parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop starting with 7.8.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
-\par \hich\af2\dbch\af31505\loch\f2         Administrator\hich\af2\dbch\af31505\loch\f2 s
+\par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
 \par \hich\af2\dbch\af31505\loch\f2         AppDNA
-\par \hich\af2\dbch\af31505\loch\f2         Application Groups
+\par \hich\af2\dbch\af31505\loch\f2         Application Group\hich\af2\dbch\af31505\loch\f2 s
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
@@ -403,8 +403,8 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Summary i\hich\af2\dbch\af31505\loch\f2 nformation is what is shown in the top half of Citrix Studio for:
-\par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
+\par \hich\af2\dbch\af31505\loch\f2         Machine Ca\hich\af2\dbch\af31505\loch\f2 talogs
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
@@ -418,21 +418,21 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can g\hich\af2\dbch\af31505\loch\f2 enerate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
+\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups \hich\af2\dbch\af31505\loch\f2 parameters can cause the report to
 \par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the X\hich\af2\dbch\af31505\loch\f2 enDesktop 7.8+ Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents \hich\af2\dbch\af31505\loch\f2 and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Finnish
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -446,19 +446,19 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect
 \par \hich\af2\dbch\af31505\loch\f2         to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
+\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter defaults to LocalHost.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                LocalHost
+\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
@@ -470,10 +470,10 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Po\hich\af2\dbch\af31505\loch\f2 sition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -484,10 +484,10 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -500,27 +500,27 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with th\hich\af2\dbch\af31505\loch\f2 e MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
@@ -533,22 +533,22 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Posit\hich\af2\dbch\af31505\loch\f2 ion?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page \hich\af2\dbch\af31505\loch\f2 to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supp\hich\af2\dbch\af31505\loch\f2 orted.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin \hich\af2\dbch\af31505\loch\f2 (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
@@ -557,29 +557,29 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date d\hich\af2\dbch\af31505\loch\f2 oesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 man\hich\af2\dbch\af31505\loch\f2 ually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 20\hich\af2\dbch\af31505\loch\f2 10/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 20\hich\af2\dbch\af31505\loch\f2 13/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word \hich\af2\dbch\af31505\loch\f2 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
@@ -590,20 +590,20 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:user\hich\af2\dbch\af31505\loch\f2 name
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alia\hich\af2\dbch\af31505\loch\f2 s of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env\hich\af2\dbch\af31505\loch\f2 :username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
@@ -617,27 +617,27 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be ins\hich\af2\dbch\af31505\loch\f2 talled.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
@@ -650,23 +650,23 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Admin\hich\af2\dbch\af31505\loch\f2 istrator Scopes and Roles.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AppDisks [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all AppDisks.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of \hich\af2\dbch\af31505\loch\f2 AD.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AD.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -678,20 +678,20 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller \hich\af2\dbch\af31505\loch\f2 section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         For Word and PDF out\hich\af2\dbch\af31505\loch\f2 put, this adds eights pages, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                 \hich\af2\dbch\af31505\loch\f2    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -753,7 +753,7 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value  \hich\af2\dbch\af31505\loch\f2               False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -768,46 +768,46 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Required?          \hich\af2\dbch\af31505\loch\f2           false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      End date for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   End date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
+\par \hich\af2\dbch\af31505\loch\f2         The default is today's\hich\af2\dbch\af31505\loch\f2  date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take \hich\af2\dbch\af31505\loch\f2 a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     long report.
+\par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
@@ -824,23 +824,23 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
 \par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           StoreFront
+\par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Does not change the value of NoADPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fal\hich\af2\dbch\af31505\loch\f2 se
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Sit\hich\af2\dbch\af31505\loch\f2 e and Citrix AD based Policies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
@@ -1060,7 +1060,7 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 OU\hich\af2\dbch\af31505\loch\f2 TPUTS
+\par \hich\af2\dbch\af31505\loch\f2 OUT\hich\af2\dbch\af31505\loch\f2 PUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
 \par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
 \par 
@@ -1068,50 +1068,51 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.05
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: June 24, 2017
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: June 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6947370 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 
+, 2017
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the s\hich\af2\dbch\af31505\loch\f2 cript for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for \hich\af2\dbch\af31505\loch\f2 the AdminAddress.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 Name="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Us\hich\af2\dbch\af31505\loch\f2 er Name.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF fi\hich\af2\dbch\af31505\loch\f2 le.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company\hich\af2\dbch\af31505\loch\f2  Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for th\hich\af2\dbch\af31505\loch\f2 e Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1119,11 +1120,11 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -TEXT
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all def\hich\af2\dbch\af31505\loch\f2 ault values and save the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:us\hich\af2\dbch\af31505\loch\f2 ername = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1131,12 +1132,12 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -HT\hich\af2\dbch\af31505\loch\f2 ML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1145,62 +1146,62 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PS\hich\af2\dbch\af31505\loch\f2 Script >.\\XD7_Inventory_V2.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sidel\hich\af2\dbch\af31505\loch\f2 ine for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops\hich\af2\dbch\af31505\loch\f2  in all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 -DeliveryGroupsUtilization
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilizati\hich\af2\dbch\af31505\loch\f2 on details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1208,14 +1209,14 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates\hich\af2\dbch\af31505\loch\f2  a report with full details for all applications.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default valu\hich\af2\dbch\af31505\loch\f2 es.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Ca\hich\af2\dbch\af31505\loch\f2 rl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company\hich\af2\dbch\af31505\loch\f2  Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1227,25 +1228,25 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript \hich\af2\dbch\af31505\loch\f2 >.\\XD7_Inventory_V2.ps1 -NoPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1253,37 +1254,37 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based\hich\af2\dbch\af31505\loch\f2  Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username\hich\af2\dbch\af31505\loch\f2  = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover \hich\af2\dbch\af31505\loch\f2 Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in \hich\af2\dbch\af31505\loch\f2 Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Pag\hich\af2\dbch\af31505\loch\f2 e format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Administrators
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory_V2.ps1 -Administrators
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
 \par 
@@ -1293,13 +1294,13 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------\hich\af2\dbch\af31505\loch\f2 ------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/\hich\af2\dbch\af31505\loch\f2 2017
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate 01/31/2017
 \par 
@@ -1308,7 +1309,7 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1318,24 +1319,24 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01\hich\af2\dbch\af31505\loch\f2 /2017 10:00:00"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate "06/01/2017 14:00:00"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the \hich\af2\dbch\af31505\loch\f2 time range
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
 \par \hich\af2\dbch\af31505\loch\f2     06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must b\hich\af2\dbch\af31505\loch\f2 e either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username \hich\af2\dbch\af31505\loch\f2 = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
@@ -1345,10 +1346,10 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1356,11 +1357,11 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  report with full details for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1374,21 +1375,21 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2         Mac\hich\af2\dbch\af31505\loch\f2 hines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Ad\hich\af2\dbch\af31505\loch\f2 ministrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
@@ -1396,26 +1397,26 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Desktops in \hich\af2\dbch\af31505\loch\f2 all Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USE\hich\af2\dbch\af31505\loch\f2 R\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administra\hich\af2\dbch\af31505\loch\f2 tor for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2     Wi\hich\af2\dbch\af31505\loch\f2 ll use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
@@ -1429,29 +1430,29 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         C\hich\af2\dbch\af31505\loch\f2 arl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock \hich\af2\dbch\af31505\loch\f2 Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 175\hich\af2\dbch\af31505\loch\f2 3 276200"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Comp\hich\af2\dbch\af31505\loch\f2 any Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 \hich\af2\dbch\af31505\loch\f2 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -\hich\af2\dbch\af31505\loch\f2 UserName "Dr. Watson"
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
@@ -1465,48 +1466,48 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover \hich\af2\dbch\af31505\loch\f2 Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_18\hich\af2\dbch\af31505\loch\f2 00.docx
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF -AddDateTime
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_2017-06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_1800.docx
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -PDF -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time s\hich\af2\dbch\af31505\loch\f2 tamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_1800.pdf
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.\hich\af2\dbch\af31505\loch\f2 ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Adm\hich\af2\dbch\af31505\loch\f2 inistrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1514,16 +1515,16 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\\hich\af2\dbch\af31505\loch\f2 FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:usernam\hich\af2\dbch\af31505\loch\f2 e = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
@@ -1536,7 +1537,7 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1548,35 +1549,15 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send e\hich\af2\dbch\af31505\loch\f2 mail,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 31 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWe\hich\af2\dbch\af31505\loch\f2 bster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     If the cu\hich\af2\dbch\af31505\loch\f2 rrent user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
@@ -1585,16 +1566,36 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 33 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" \hich\af2\dbch\af31505\loch\f2 or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1607,7 +1608,7 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1615,16 +1616,16 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Processes only the Delivery Groups section of the report with no Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default va\hich\af2\dbch\af31505\loch\f2 lues.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Ca\hich\af2\dbch\af31505\loch\f2 rl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1639,21 +1640,21 @@ XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators      = T\hich\af2\dbch\af31505\loch\f2 rue
+\par \hich\af2\dbch\af31505\loch\f2     Set the foll\hich\af2\dbch\af31505\loch\f2 owing parameter values:
+\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks            = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
-\par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
+\par \hich\af2\dbch\af31505\loch\f2         Hosting       \hich\af2\dbch\af31505\loch\f2       = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
@@ -1783,10 +1784,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000a099
-64200cedd20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000a09964200cedd201
-a09964200cedd2010000000000000000000000004b004d00d500d00053003200d100da00510055004f0051004e004200d300c000da00cc005a004b005900d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000a09964200ced
-d201a09964200cedd2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000090a9
+7e36e5edd20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000090a97e36e5edd201
+90a97e36e5edd201000000000000000000000000c300dc004200c4004e0034004a004900cc00c4005700d100c500cd00d600c700cd00510051003000cd00c0003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000090a97e36e5ed
+d20190a97e36e5edd2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1794,7 +1795,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b34393730434432382d374143432d343334312d393033342d3143453045414336344136337d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b33353634433038462d343845322d343542322d423139362d4444413742353034314142367d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f42\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f42\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f43\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f44\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -72,13 +72,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid677819\rsid928241\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3430394\rsid3761251\rsid3830441\rsid4149699\rsid4357927
-\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12353294\rsid12602409\rsid12801149
-\rsid12863195\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
-\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo6\dy16\hr20\min51}{\version26}{\edmins11720}{\nofpages28}{\nofwords8379}{\nofchars47765}{\nofcharsws56032}{\vern37}}
-{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid346080\rsid677819\rsid928241\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3430394\rsid3761251\rsid3830441\rsid4149699
+\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9639341\rsid9974690\rsid9986361\rsid11488686\rsid11823514\rsid12272355\rsid12353294\rsid12602409
+\rsid12801149\rsid12863195\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid16207041\rsid16272684\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1
+\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2017\mo6\dy24\hr12\min5}{\version27}{\edmins11727}{\nofpages26}{\nofwords8362}{\nofchars47666}{\nofcharsws55917}
+{\vern37}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBca1ADkwyV4sAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -186,7 +186,7 @@ PVS PowerShell SDK x??
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb2000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff22}}}{\fldrslt {
+3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000037000000080002000000000000ff226b}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -224,7 +224,7 @@ If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \lt
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe0000002200300000000000000064}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe000000220030000000000000006400}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 .  The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated v\hich\af37\dbch\af31505\loch\f37 ersion is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 
 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -285,61 +285,103 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af42\dbch\af31505\loch\f42 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af42\hich\af42\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8876191 
-\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7763859 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7763859\charrsid7763859 \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\
-XD7_Inventory_V2.ps1 -full
+\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid346080 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 PS C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 > get-help .\\XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site.
 \par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
-\par \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
-\par \hich\af2\dbch\af31505\loch\f2     [-MSWord] [-Ad\hich\af2\dbch\af31505\loch\f2 ministrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups]
-\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>]
-\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPoli\hich\af2\dbch\af31505\loch\f2 cies] [-StoreFront] [-AddDateTime] [-Folder
-\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Administra\hich\af2\dbch\af31505\loch\f2 tors] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-Stor\hich\af2\dbch\af31505\loch\f2 eFront] [-AddDateTime] [-Folder <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
-\par \hich\af2\dbch\af31505\loch\f2     [-HTML] [-MSWord] [-PDF] [-Text] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys]
-\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroups] [-DeliveryGrou\hich\af2\dbch\af31505\loch\f2 psUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>]
-\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder
-\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] -SmtpServe\hich\af2\dbch\af31505\loch\f2 r <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To
-\par \hich\af2\dbch\af31505\loch\f2     <String> [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String\hich\af2\dbch\af31505\loch\f2 >] [-CompanyName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-Text] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting\hich\af2\dbch\af31505\loch\f2 ] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] -SmtpServer <String> [-SmtpPort <Int32>] [\hich\af2\dbch\af31505\loch\f2 -UseSSL] 
+}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [-Dev] [-ScriptInfo]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]
-\par \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <Str\hich\af2\dbch\af31505\loch\f2 ing>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>]
-\par \hich\af2\dbch\af31505\loch\f2     [-PDF] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups]
-\par \hich\af2\dbch\af31505\loch\f2     [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-Star\hich\af2\dbch\af31505\loch\f2 tDate <DateTime>] [-EndDate <DateTime>]
-\par \hich\af2\dbch\af31505\loch\f2     [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder
-\par \hich\af2\dbch\af31505\loch\f2     <String>] [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Comp\hich\af2\dbch\af31505\loch\f2 anyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-Policies] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] [-AppDisks]
-\par \hich\af2\dbch\af31505\loch\f2     [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging]
-\par \hich\af2\dbch\af31505\loch\f2     [-StartDate <DateTime>] [-EndDate <D\hich\af2\dbch\af31505\loch\f2 ateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies]
-\par \hich\af2\dbch\af31505\loch\f2     [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev]
-\par \hich\af2\dbch\af31505\loch\f2     [-ScriptInfo] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-AdminAddress <\hich\af2\dbch\af31505\loch\f2 String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicie\hich\af2\dbch\af31505\loch\f2 s] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies] [-StoreFront] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps\hich\af2\dbch\af31505\loch\f2 1 [-AdminAddress <String>] [-Text] [-Administrators] [-AppDisks]
-\par \hich\af2\dbch\af31505\loch\f2     [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging]
-\par \hich\af2\dbch\af31505\loch\f2     [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetail\hich\af2\dbch\af31505\loch\f2 s] [-Policies] [-NoPolicies]
-\par \hich\af2\dbch\af31505\loch\f2     [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev]
-\par \hich\af2\dbch\af31505\loch\f2     [-ScriptInfo] [<CommonParameters>]
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-AppDisks] [-App\hich\af2\dbch\af31505\loch\f2 lications] [-BrokerRegistryKeys] [-DeliveryGroups] }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site using Mic\hich\af2\dbch\af31505\loch\f2 rosoft PowerShell, Word,
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site using Microsoft PowerShell, Word,
 \par \hich\af2\dbch\af31505\loch\f2     plain text or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This Script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this scrip\hich\af2\dbch\af31505\loch\f2 t on a Controller. This script was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and r\hich\af2\dbch\af31505\loch\f2 un
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 10 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
@@ -347,7 +389,7 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop starting with 7.8.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators
+\par \hich\af2\dbch\af31505\loch\f2         Administrator\hich\af2\dbch\af31505\loch\f2 s
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
 \par \hich\af2\dbch\af31505\loch\f2         AppDNA
@@ -356,18 +398,18 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         Logging
-\par \hich\af2\dbch\af31505\loch\f2         Machine Cata\hich\af2\dbch\af31505\loch\f2 logs
+\par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
+\par \hich\af2\dbch\af31505\loch\f2     The Summary i\hich\af2\dbch\af31505\loch\f2 nformation is what is shown in the top half of Citrix Studio for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2         Loggi\hich\af2\dbch\af31505\loch\f2 ng
+\par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
@@ -376,21 +418,21 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     complete and can g\hich\af2\dbch\af31505\loch\f2 enerate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     take an extremely \hich\af2\dbch\af31505\loch\f2 long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the X\hich\af2\dbch\af31505\loch\f2 enDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following langua\hich\af2\dbch\af31505\loch\f2 ge versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2         Finnish
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -400,7 +442,7 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <S\hich\af2\dbch\af31505\loch\f2 tring>
+\par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect
 \par \hich\af2\dbch\af31505\loch\f2         to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
@@ -409,30 +451,30 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -442,24 +484,24 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -471,98 +513,98 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page \hich\af2\dbch\af31505\loch\f2 to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date d\hich\af2\dbch\af31505\loch\f2 oesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manuall\hich\af2\dbch\af31505\loch\f2 y changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Mod (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't f\hich\af2\dbch\af31505\loch\f2 it; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 20\hich\af2\dbch\af31505\loch\f2 16, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 20\hich\af2\dbch\af31505\loch\f2 13/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless \hich\af2\dbch\af31505\loch\f2 changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:user\hich\af2\dbch\af31505\loch\f2 name
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only val\hich\af2\dbch\af31505\loch\f2 id with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env\hich\af2\dbch\af31505\loch\f2 :username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard chara\hich\af2\dbch\af31505\loch\f2 cters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
@@ -570,102 +612,102 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value  \hich\af2\dbch\af31505\loch\f2               False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word Save\hich\af2\dbch\af31505\loch\f2 As PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Admin\hich\af2\dbch\af31505\loch\f2 istrator Scopes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AppDisks [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all AppDisks.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AD.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of \hich\af2\dbch\af31505\loch\f2 AD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller \hich\af2\dbch\af31505\loch\f2 section.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   For Text and HTML, this adds 315 lines, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                 \hich\af2\dbch\af31505\loch\f2    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause\hich\af2\dbch\af31505\loch\f2  the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate a\hich\af2\dbch\af31505\loch\f2 n exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         Using bot\hich\af2\dbch\af31505\loch\f2 h the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an ali\hich\af2\dbch\af31505\loch\f2 as of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -673,24 +715,24 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 da\hich\af2\dbch\af31505\loch\f2 ys
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilizatio\hich\af2\dbch\af31505\loch\f2 n [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
 \par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
+\par \hich\af2\dbch\af31505\loch\f2         Micro\hich\af2\dbch\af31505\loch\f2 soft Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes\hich\af2\dbch\af31505\loch\f2  the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections, and Resources.
@@ -698,16 +740,16 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
+\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by\hich\af2\dbch\af31505\loch\f2  default, details for the previous
 \par \hich\af2\dbch\af31505\loch\f2         seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter has an alias of Log.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Log.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -715,7 +757,7 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Star\hich\af2\dbch\af31505\loch\f2 tDate <DateTime>
+\par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
@@ -726,49 +768,49 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDa\hich\af2\dbch\af31505\loch\f2 ys(-7))
+\par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         End date for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      End date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific\hich\af2\dbch\af31505\loch\f2  time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in a\hich\af2\dbch\af31505\loch\f2 ll Machine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take \hich\af2\dbch\af31505\loch\f2 a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
 \par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter has an alias of MC.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MaxDeta\hich\af2\dbch\af31505\loch\f2 ils [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
@@ -776,13 +818,13 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2                 AppDisks
 \par \hich\af2\dbch\af31505\loch\f2                 Applications
 \par \hich\af2\dbch\af31505\loch\f2                 BrokerRegistryKeys
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2                 DeliveryGroups
 \par \hich\af2\dbch\af31505\loch\f2                 HardWare
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
 \par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
-\par \hich\af2\dbch\af31505\loch\f2                 StoreFront
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
 \par 
@@ -791,33 +833,33 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using th\hich\af2\dbch\af31505\loch\f2 e Policies parameter can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         There are three relate\hich\af2\dbch\af31505\loch\f2 d parameters: Policies, NoPolicies and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutua\hich\af2\dbch\af31505\loch\f2 lly exclusive and priority is given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD-based policy information from the output document.
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all \hich\af2\dbch\af31505\loch\f2 Site and Citrix AD-based policy information from the output document.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
 \par 
@@ -825,17 +867,17 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output\hich\af2\dbch\af31505\loch\f2  document.
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
 \par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSV\hich\af2\dbch\af31505\loch\f2 OL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
@@ -843,7 +885,7 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
@@ -851,25 +893,25 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the \hich\af2\dbch\af31505\loch\f2 end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2017 at 6PM is 2017-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2017-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter has an alias of ADT.
+\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
@@ -877,41 +919,41 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipe\hich\af2\dbch\af31505\loch\f2 line input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevate\hich\af2\dbch\af31505\loch\f2 d PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may requir\hich\af2\dbch\af31505\loch\f2 e the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         size of th\hich\af2\dbch\af31505\loch\f2 e report.
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String>
 \par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
-\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
+\par \hich\af2\dbch\af31505\loch\f2         Vali\hich\af2\dbch\af31505\loch\f2 d options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 AppDisks
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              AppDNA
+\par \hich\af2\dbch\af31505\loch\f2                 AppDNA
 \par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
-\par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
+\par \hich\af2\dbch\af31505\loch\f2                 Config\hich\af2\dbch\af31505\loch\f2  (Configuration)
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
-\par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Group\hich\af2\dbch\af31505\loch\f2 s)
+\par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
@@ -922,9 +964,9 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
-\par \hich\af2\dbch\af31505\loch\f2         Using Loggin\hich\af2\dbch\af31505\loch\f2 g will force the Logging switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, the script will terminate.
+\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, \hich\af2\dbch\af31505\loch\f2 the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -932,17 +974,17 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the outp\hich\af2\dbch\af31505\loch\f2 ut report.
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServe\hich\af2\dbch\af31505\loch\f2 r <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP p\hich\af2\dbch\af31505\loch\f2 ort.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -951,29 +993,19 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSS\hich\af2\dbch\af31505\loch\f2 L [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpSe\hich\af2\dbch\af31505\loch\f2 rver is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If \hich\af2\dbch\af31505\loch\f2 SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -981,24 +1013,34 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -To <St\hich\af2\dbch\af31505\loch\f2 ring>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is r\hich\af2\dbch\af31505\loch\f2 un.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
@@ -1006,31 +1048,27 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and \hich\af2\dbch\af31505\loch\f2 OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable,\hich\af2\dbch\af31505\loch\f2  WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
+\par \hich\af2\dbch\af31505\loch\f2 OU\hich\af2\dbch\af31505\loch\f2 TPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
 \par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, plain text, or HTML document.
 \par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.05
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: June 16, 2017
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: June 24, 2017
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1039,69 +1077,57 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the s\hich\af2\dbch\af31505\loch\f2 cript for the AdminAddress.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     DDC01 \hich\af2\dbch\af31505\loch\f2 for the AdminAddress.
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF fi\hich\af2\dbch\af31505\loch\f2 le.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company\hich\af2\dbch\af31505\loch\f2  Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -T\hich\af2\dbch\af31505\loch\f2 EXT
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -TEXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="\hich\af2\dbch\af31505\loch\f2 Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
@@ -1110,15 +1136,12 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
@@ -1126,23 +1149,20 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sidel\hich\af2\dbch\af31505\loch\f2 ine for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Grou\hich\af2\dbch\af31505\loch\f2 ps.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops\hich\af2\dbch\af31505\loch\f2  in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
@@ -1153,69 +1173,72 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 -DeliveryGroupsUtilization
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 Name="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Us\hich\af2\dbch\af31505\loch\f2 er Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all deskt\hich\af2\dbch\af31505\loch\f2 ops in all Delivery Groups.
+\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:u\hich\af2\dbch\af31505\loch\f2 sername = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates\hich\af2\dbch\af31505\loch\f2  a report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HK\hich\af2\dbch\af31505\loch\f2 EY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Ca\hich\af2\dbch\af31505\loch\f2 rl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 12 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoPolicies
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
@@ -1226,116 +1249,43 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoPolicies
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy informatio\hich\af2\dbch\af31505\loch\f2 n.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based\hich\af2\dbch\af31505\loch\f2  Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username\hich\af2\dbch\af31505\loch\f2  = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Pag\hich\af2\dbch\af31505\loch\f2 e format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Adm\hich\af2\dbch\af31505\loch\f2 inistrator Scopes and Roles.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate 01/31/2017
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/2017 through
-\par \hich\af2\dbch\af31505\loch\f2     01/31/2017.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate "06/01/2017 14:00:00\hich\af2\dbch\af31505\loch\f2 "
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
-\par \hich\af2\dbch\af31505\loch\f2     06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1347,46 +1297,77 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/\hich\af2\dbch\af31505\loch\f2 2017
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate 01/31/2017
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/2017 through
+\par \hich\af2\dbch\af31505\loch\f2     01/31/2017.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate "06/01/2017 14:00:00"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the \hich\af2\dbch\af31505\loch\f2 time range
+\par \hich\af2\dbch\af31505\loch\f2     06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hosting
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a re\hich\af2\dbch\af31505\loch\f2 port with full details for Hosts, Host Connections, and Resources.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections, and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRE\hich\af2\dbch\af31505\loch\f2 NT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications
 \par 
@@ -1400,46 +1381,39 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microso\hich\af2\dbch\af31505\loch\f2 ft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page for\hich\af2\dbch\af31505\loch\f2 mat.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Machine\hich\af2\dbch\af31505\loch\f2 s in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2         Desktops in \hich\af2\dbch\af31505\loch\f2 all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USE\hich\af2\dbch\af31505\loch\f2 R\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 22 --------------------------
 \par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPag\hich\af2\dbch\af31505\loch\f2 e "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
@@ -1447,126 +1421,69 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
 \par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (al\hich\af2\dbch\af31505\loch\f2 ias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         C\hich\af2\dbch\af31505\loch\f2 arl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 >PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 175\hich\af2\dbch\af31505\loch\f2 3 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 \hich\af2\dbch\af31505\loch\f2 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -\hich\af2\dbch\af31505\loch\f2 UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         Su\hich\af2\dbch\af31505\loch\f2 perSleuth@SherlockHolmes.com for the Compnay Email.
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compnay Email.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover \hich\af2\dbch\af31505\loch\f2 Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_2017-06-01_1800.docx
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_18\hich\af2\dbch\af31505\loch\f2 00.docx
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURR\hich\af2\dbch\af31505\loch\f2 ENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideli\hich\af2\dbch\af31505\loch\f2 ne for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2017-06-01_1800.pdf
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page \hich\af2\dbch\af31505\loch\f2 format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
@@ -1576,21 +1493,50 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2017 at 6PM is 2017-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_2017-06-01_1800.pdf
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 30 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_\hich\af2\dbch\af31505\loch\f2 V2.ps1 -SmtpServer mail.domain.tld
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1602,45 +1548,38 @@ XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send e\hich\af2\dbch\af31505\loch\f2 mail,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 31 --------------------------
 \par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@Car\hich\af2\dbch\af31505\loch\f2 lWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid346080\charrsid346080 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the cu\hich\af2\dbch\af31505\loch\f2 rrent user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
-\par 
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1648,33 +1587,27 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Web\hich\af2\dbch\af31505\loch\f2 ster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Proce\hich\af2\dbch\af31505\loch\f2 sses only the Delivery Groups section of the report with Delivery Group details.
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1682,19 +1615,16 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
-\par 
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PS\hich\af2\dbch\af31505\loch\f2 Script >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default va\hich\af2\dbch\af31505\loch\f2 lues.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="\hich\af2\dbch\af31505\loch\f2 Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1702,31 +1632,28 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on 315 Broker registry keys to the Controllers section.
 \par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 36 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 36 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the follo\hich\af2\dbch\af31505\loch\f2 wing parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
+\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
+\par \hich\af2\dbch\af31505\loch\f2         Administrators      = T\hich\af2\dbch\af31505\loch\f2 rue
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks            = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
-\par \hich\af2\dbch\af31505\loch\f2         Hosting        \hich\af2\dbch\af31505\loch\f2      = True
+\par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
@@ -1735,15 +1662,8 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
-\par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting>}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12353294\charrsid12353294 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -1863,10 +1783,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000504d
-a9460ce7d20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000504da9460ce7d201
-504da9460ce7d201000000000000000000000000c600cf00cf004d0045004a00d500c800c600d40034004400ce004500c900430030003000c100cf00dd00c0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000504da9460ce7
-d201504da9460ce7d2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000a099
+64200cedd20103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000a09964200cedd201
+a09964200cedd2010000000000000000000000004b004d00d500d00053003200d100da00510055004f0051004e004200d300c000da00cc005a004b005900d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000a09964200ced
+d201a09964200cedd2010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1874,7 +1794,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b31304343464239412d363839442d343739422d383342382d3441343236394138364646367d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b34393730434432382d374143432d343334312d393033342d3143453045414336344136337d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -9,17 +9,17 @@
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added back the WorkerGroup policy filter for XenApp 6.x
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
 #		Application Launch Wait Timeout
 #		Enable monitoring of application failures
 #		Enable monitoring of application failures on Desktop OS VDAs
 #		List of applications excluded from failure monitoring
-#		Logoff Checker Startup Delay
-#		Profile Streaming Exclusion list - directories (Enable/Disable)
-#		Profile Streaming Exclusion list - directories (Enable with list of folders/Disable)
+#		Logoff Checker Startup Delay (seconds)
+#		Profile Streaming Exclusion list - directories
 #	Added to Delivery Group, LicenseModel and ProductCode
-#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fix Function Check-LoadedModule
 #	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -10,14 +10,30 @@
 #		Added Function Get-RegistryValue2
 #		Added Function Get-RegKeyToObject
 #		Added Function OutputControllerRegistryKeys
+#		Added new parameter BrokerRegistryKeys
 #		There are 315 registry keys and values that are checked and listed
 #		Updated Function OutputControllers
+#	Added Controller version information to the Controllers section
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added missing function validObject
+#	Added new parameter MaxDetails:
+#		This is the same as using the follwoing parameters:
+#			Administrators
+#			AppDisks
+#			Applications
+#			BrokerRegistryKeys
+#			DeliveryGroups
+#			HardWare
+#			Hosting
+#			Logging
+#			MachineCatalogs
+#			Policies
+#			StoreFront
 #	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
@@ -28,16 +44,19 @@
 #		Logoff Checker Startup Delay (seconds)
 #		Profile Streaming Exclusion list - directories
 #	Added to Delivery Group, LicenseModel and ProductCode
-#	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
-#	Fix Function Check-LoadedModule
-#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
-#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
-#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
-#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Update Function ProcessScriptEnd for the new Cover Page properties
-#	Update Function ShowScriptOptions for the new Cover Page properties
-#	Update Function UpdateDocumentProperties for the new Cover Page properties
-#	Update help text
+#	Added Version information to Controllers
+#	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
+#	Fixed Function Check-LoadedModule
+#	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fixed numerous issues in the Policies section
+#	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
+#	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Reordered the parameters in the help text and parameter list so they match and are grouped better
+#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Updated Function ProcessScriptEnd for the new Cover Page properties
+#	Updated Function ShowScriptOptions for the new Cover Page properties
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated help text
 
 #Version 2.04 released 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -25,6 +25,7 @@
 #		Company Email
 #		Company Fax
 #		Company Phone
+#	Added loading the SQL Server assembly so the database size calculations work consistently (thanks to Michael B. Smith)
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
 #		This is the same as using the following parameters:
@@ -55,11 +56,16 @@
 #	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
+#	Fixed the "CPU Usage", "Disk Usage", and "Memory Usage" policy settings
+#		When those settings are Disabled, they are stored as Enabled with a Value of -1
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function OutputDatastores to add database size
+#	Updated Function OutputDatastores to:
+#		Add database size
+#		Fix output for mirrored databases
+#		Check if SQL Server assembly is loaded before calculating database size
 #	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
 #	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
 #	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -18,6 +18,7 @@
 #		There are 315 registry keys and values that are checked and listed
 #		Updated Function OutputControllers
 #	Added Controller version information to the Controllers section
+#	Added "Database Size" to the Datastores output
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address
@@ -58,9 +59,10 @@
 #	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Reordered the parameters in the help text and parameter list so they match and are grouped better
 #	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function ProcessScriptEnd for the new Cover Page properties
-#	Updated Function ShowScriptOptions for the new Cover Page properties
-#	Updated Function UpdateDocumentProperties for the new Cover Page properties
+#	Updated Function OutputDatastores to add database size
+#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
+#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
 #	Updated help text
 #	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for
 

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -5,6 +5,13 @@
 
 #Version 2.05
 #	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added Broker registry keys that can be set on Broker servers
+#		Added Function GetControllerRegistryKeys
+#		Added Function Get-RegistryValue2
+#		Added Function Get-RegKeyToObject
+#		Added Function OutputControllerRegistryKeys
+#		There are 315 registry keys and values that are checked and listed
+#		Updated Function OutputControllers
 #	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
 #	Added four new Cover Page properties
 #		Company Address

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -4,12 +4,14 @@
 # Created on October 20, 2013
 
 #Version 2.05
-#	Add four new Cover Page properties
+#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
+#	Added four new Cover Page properties
 #		Company Address
 #		Company Email
 #		Company Fax
 #		Company Phone
-#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
 #	Added support for version 7.14
 #	Added the following new Computer policy settings:
 #		Application Launch Wait Timeout
@@ -21,6 +23,8 @@
 #	Added to Delivery Group, LicenseModel and ProductCode
 #	Fix bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fix Function Check-LoadedModule
+#	Fix functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
+#	Fix two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
 #	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
 #	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
 #	Update Function ProcessScriptEnd for the new Cover Page properties
@@ -75,10 +79,10 @@
 #	Fix numerous typos
 #	Fixed formatting issues with HTML headings output
 #	Fixed French wording for Table of Contents 2 (Thanks to David Rouquier)
-#	Fixed the ‚ÄúNo. of machines‚Äù for Machine Catalogs so it is now accurate
+#	Fixed the ìNo. of machinesî for Machine Catalogs so it is now accurate
 #	Fixed the Machine Catalog details to match what is shown in Studio
 #	For Machine Catalog details, for PVS provisioned catalogs, add the PVS Server address
-#	For Persistent machines with changes stored on the local disk, added the ‚ÄúVM copy mode‚Äù
+#	For Persistent machines with changes stored on the local disk, added the ìVM copy modeî
 #	For Personal vDisk catalogs, added PvD size and drive letter
 #	For Random catalog types (SingleSession and MultiSession), added "Temporary memory cache size (MB)" and "Temporary disk cache size (GB)"
 #	Removed unnecessary blank lines in policy value output

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,31 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.05
+#	Add four new Cover Page properties
+#		Company Address
+#		Company Email
+#		Company Fax
+#		Company Phone
+#	Added support for version 7.14
+#	Added the following new Computer policy settings:
+#		Application Launch Wait Timeout
+#		Enable monitoring of application failures
+#		Enable monitoring of application failures on Desktop OS VDAs
+#		List of applications excluded from failure monitoring
+#		Logoff Checker Startup Delay
+#		Profile Streaming Exclusion list - directories (Enable/Disable)
+#		Profile Streaming Exclusion list - directories (Enable with list of folders/Disable)
+#	Added to Delivery Group, LicenseModel and ProductCode
+#	Added back the WorkerGroup policy filter for XenApp 6.x
+#	Fix Function Check-LoadedModule
+#	Remove code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Replace _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Update Function ProcessScriptEnd for the new Cover Page properties
+#	Update Function ShowScriptOptions for the new Cover Page properties
+#	Update Function UpdateDocumentProperties for the new Cover Page properties
+#	Update help text
+
 #Version 2.04 released 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM
 #		URL Redirection -> Bidirectional Content Redirection
@@ -50,10 +75,10 @@
 #	Fix numerous typos
 #	Fixed formatting issues with HTML headings output
 #	Fixed French wording for Table of Contents 2 (Thanks to David Rouquier)
-#	Fixed the ìNo. of machinesî for Machine Catalogs so it is now accurate
+#	Fixed the ‚ÄúNo. of machines‚Äù for Machine Catalogs so it is now accurate
 #	Fixed the Machine Catalog details to match what is shown in Studio
 #	For Machine Catalog details, for PVS provisioned catalogs, add the PVS Server address
-#	For Persistent machines with changes stored on the local disk, added the ìVM copy modeî
+#	For Persistent machines with changes stored on the local disk, added the ‚ÄúVM copy mode‚Äù
 #	For Personal vDisk catalogs, added PvD size and drive letter
 #	For Random catalog types (SingleSession and MultiSession), added "Temporary memory cache size (MB)" and "Temporary disk cache size (GB)"
 #	Removed unnecessary blank lines in policy value output

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -4,6 +4,10 @@
 # Created on October 20, 2013
 
 #Version 2.05
+#	Added additional error checking for Site version information
+#		If "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Citrix Desktop Delivery Controller" 
+#		is not found on the computer running the script, then look on the computer specified for -AdminAddress
+#		If still not found on that computer, abort the script
 #	Added back the WorkerGroup policy filter for XenApp 6.x
 #	Added Broker registry keys that can be set on Broker servers
 #		Added Function GetControllerRegistryKeys
@@ -22,7 +26,7 @@
 #		Company Phone
 #	Added missing function validObject
 #	Added new parameter MaxDetails:
-#		This is the same as using the follwoing parameters:
+#		This is the same as using the following parameters:
 #			Administrators
 #			AppDisks
 #			Applications
@@ -47,6 +51,7 @@
 #	Added Version information to Controllers
 #	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
 #	Fixed Function Check-LoadedModule
+#	Fixed function OutputPolicySetting
 #	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
 #	Fixed numerous issues in the Policies section
 #	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
@@ -57,6 +62,7 @@
 #	Updated Function ShowScriptOptions for the new Cover Page properties
 #	Updated Function UpdateDocumentProperties for the new Cover Page properties
 #	Updated help text
+#	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for
 
 #Version 2.04 released 6-Mar-2017
 #	Fixed wording of more policy names that changed from 7.13 prerelease to RTM


### PR DESCRIPTION
#Version 2.05 26-Jun-2017
#	Added additional error checking for Site version information
#		If "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Citrix Desktop Delivery Controller" 
#		is not found on the computer running the script, then look on the computer specified for -AdminAddress
#		If still not found on that computer, abort the script
#	Added back the WorkerGroup policy filter for XenApp 6.x
#	Added Broker registry keys that can be set on Broker servers
#		Added Function GetControllerRegistryKeys
#		Added Function Get-RegistryValue2
#		Added Function Get-RegKeyToObject
#		Added Function OutputControllerRegistryKeys
#		Added new parameter BrokerRegistryKeys
#		There are 315 registry keys and values that are checked and listed
#		Updated Function OutputControllers
#	Added Controller version information to the Controllers section
#	Added "Database Size" to the Datastores output
#	Added folder name to Function OutputApplication (Thanks to Brandon Mitchell)
#	Added four new Cover Page properties
#		Company Address
#		Company Email
#		Company Fax
#		Company Phone
#	Added loading the SQL Server assembly so the database size calculations work consistently (thanks to Michael B. Smith)
#	Added missing function validObject
#	Added new parameter MaxDetails:
#		This is the same as using the following parameters:
#			Administrators
#			AppDisks
#			Applications
#			BrokerRegistryKeys
#			DeliveryGroups
#			HardWare
#			Hosting
#			Logging
#			MachineCatalogs
#			Policies
#			StoreFront
#	Added sort applications by AdminFolderName and ApplicationName to Function ProcessApplications (Thanks to Brandon Mitchell)
#	Added support for version 7.14
#	Added the following new Computer policy settings:
#		Application Launch Wait Timeout
#		Enable monitoring of application failures
#		Enable monitoring of application failures on Desktop OS VDAs
#		List of applications excluded from failure monitoring
#		Logoff Checker Startup Delay (seconds)
#		Profile Streaming Exclusion list - directories
#	Added to Delivery Group, LicenseModel and ProductCode
#	Added Version information to Controllers
#	Fixed bug when retrieving Filters for a Policy that "applies to all objects in the Site"
#	Fixed Function Check-LoadedModule
#	Fixed function OutputPolicySetting
#	Fixed functions ProcessAppV and OutputAppv to handle multiple AppV servers (Thanks to Brandon Mitchell)
#	Fixed numerous issues in the Policies section
#	Fixed the "CPU Usage", "Disk Usage", and "Memory Usage" policy settings
#		When those settings are Disabled, they are stored as Enabled with a Value of -1
#	Fixed two calls to Get-BrokerApplication that were retrieving the default of 250 records (Thanks to Brandon Mitchell)
#	Removed code (240 lines) that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
#	Reordered the parameters in the help text and parameter list so they match and are grouped better
#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
#	Updated Function OutputDatastores to:
#		Add database size
#		Fix output for mirrored databases
#		Check if SQL Server assembly is loaded before calculating database size
#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
#	Updated help text
#	When -NoPolicies is specified, the Citrix.GroupPolicy.Commands module is no longer searched for