### PR TITLE
Final update for 2.15

### DIFF
--- a/2.15ReadMe.md
+++ b/2.15ReadMe.md
@@ -1,0 +1,11 @@
+#Version 2.15 16-Apr-2018
+#	Added Function Get-IPAddress
+#	Added in Function OutputDatastores getting the IP address for each SQL server name
+#	Added in Function OutputLicensingOverview getting the IP address for the license server
+#	Changed from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+#	Fixed many alignment issues with Text output
+#	In the Desktop Entitlement section, Excluded Users, the wrong variable name was used. Fixed.
+#	When building the array of all Machine Catalogs that are used by a Delivery Group,
+#		Only the first item in the array was being returned. Adding -Property CatalogName 
+#		to Sort-Object was needed to get the full unique array returned.
+#		Sort-Object -Property CatalogName -Unique

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -960,9 +960,9 @@
 	This script creates a Word, PDF, plain text, or HTML document.
 .NOTES
 	NAME: XD7_Inventory_V2.ps1
-	VERSION: 2.14
+	VERSION: 2.15
 	AUTHOR: Carl Webster
-	LASTEDIT: April 11, 2018
+	LASTEDIT: April 13, 2018
 #>
 
 #endregion
@@ -1155,6 +1155,18 @@ Param(
 #started updating for version 7.8+ on April 17, 2016
 
 # This script is based on the 1.20 script
+
+#Version 2.15 16-Apr-2018
+#	Added Function Get-IPAddress
+#	Added in Function OutputDatastores getting the IP address for each SQL server name
+#	Added in Function OutputLicensingOverview getting the IP address for the license server
+#	Changed from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+#	Fixed many alignment issues with Text output
+#	In the Desktop Entitlement section, Excluded Users, the wrong variable name was used. Fixed.
+#	When building the array of all Machine Catalogs that are used by a Delivery Group,
+#		Only the first item in the array was being returned. Adding -Property CatalogName 
+#		to Sort-Object was needed to get the full unique array returned.
+#		Sort-Object -Property CatalogName -Unique
 
 #Version 2.14 11-Apr-2018
 #	Added the following properties to Application Details
@@ -5896,6 +5908,31 @@ Function TranscriptLogging
 		}
 	}
 }
+
+Function Get-IPAddress
+{
+	#V2.15 added new function
+	Param([string]$ComputerName)
+	
+	$IPAddress = "Unable to determine"
+	
+	Try
+	{
+		$IP = Test-Connection -ComputerName $ComputerName -Count 1 | Select-Object IPV4Address
+	}
+	
+	Catch
+	{
+		$IP = $Null
+	}
+
+	If($? -and $Null -ne $IP)
+	{
+		$IPAddress = $IP.IPV4Address.IPAddressToString
+	}
+	
+	Return $IPAddress
+}
 #endregion
 
 #region email function
@@ -10047,12 +10084,14 @@ Function OutputDeliveryGroupDetails
 	}
 	
 	#get a desktop in an associated delivery group to get the catalog
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
-	$Desktop = Get-BrokerDesktop @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.15 change from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+	#$Desktop = Get-BrokerDesktop @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName
+	$Desktop = Get-BrokerMachine @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName
 	
 	If($? -and $Null -ne $Desktop)
 	{
-		#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+		#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 		$Catalog = Get-BrokerCatalog @XDParams2 -Name $Desktop[0].CatalogName
 		
 		If($? -and $Null -ne $Catalog)
@@ -10080,7 +10119,7 @@ Function OutputDeliveryGroupDetails
 
 	If($PwrMgmt2 -or $PwrMgmt3)
 	{
-		#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+		#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 		$PwrMgmts = Get-BrokerPowerTimeScheme @XDParams2 -DesktopGroupUid $Group.Uid 
 	}
 	
@@ -10176,7 +10215,7 @@ Function OutputDeliveryGroupDetails
 	}
 
 	$SFAnonymousUsers = $False
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 	$Results = Get-BrokerAccessPolicyRule -DesktopGroupUid $Group.Uid @XDParams2
 	
 	If($? -and $Null -ne $Results)
@@ -10274,7 +10313,7 @@ Function OutputDeliveryGroupDetails
 		{
 			#static desktops have a maxdesktops count stored as a property
 			$xMaxDesktops = 0
-			#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+			#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 			$MaxDesktops = Get-BrokerAssignmentPolicyRule @XDParams2 -DesktopGroupUid $Group.Uid
 			
 			If($? -and $Null -ne $MaxDesktops)
@@ -10286,7 +10325,7 @@ Function OutputDeliveryGroupDetails
 		{
 			#random desktops are a count of the number of entitlement policy rules
 			$xMaxDesktops = 0
-			#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+			#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 			$MaxDesktops = Get-BrokerEntitlementPolicyRule @XDParams2 -DesktopGroupUid $Group.Uid
 			
 			If($? -and $Null -ne $MaxDesktops)
@@ -10375,7 +10414,8 @@ Function OutputDeliveryGroupDetails
 			{
 				$ScriptInformation += @{Data = "     Excluded Users"; Value = $DesktopSettingsExcludedUsers[0]; }
 				$cnt = -1
-				ForEach($tmp in $DGExcludedUsers)
+				#V2.15 changed to use correct variable name
+				ForEach($tmp in $DesktopSettingsExcludedUsers)
 				{
 					$cnt++
 					If($cnt -gt 0)
@@ -10806,7 +10846,7 @@ Function OutputDeliveryGroupDetails
 				$cnt++
 				If($cnt -gt 0)
 				{
-					Line 7 "" $tmp
+					Line 7 "  " $tmp
 				}
 			}
 			
@@ -10814,12 +10854,13 @@ Function OutputDeliveryGroupDetails
 			{
 				Line 2 "Excluded Users`t`t`t`t: " $DesktopSettingsExcludedUsers[0]
 				$cnt = -1
-				ForEach($tmp in $DGExcludedUsers)
+				#V2.15 changed to use correct variable name
+				ForEach($tmp in $DesktopSettingsExcludedUsers)
 				{
 					$cnt++
 					If($cnt -gt 0)
 					{
-						Line 7 "" $tmp
+						Line 7 "  " $tmp
 					}
 				}
 			}
@@ -11235,7 +11276,8 @@ Function OutputDeliveryGroupDetails
 			{
 				$rowdata += @(,("     Excluded Users",($htmlsilver -bor $htmlbold),$DesktopSettingsExcludedUsers[0],$htmlwhite))
 				$cnt = -1
-				ForEach($tmp in $DGExcludedUsers)
+				#V2.15 changed to use correct variable name
+				ForEach($tmp in $DesktopSettingsExcludedUsers)
 				{
 					$cnt++
 					If($cnt -gt 0)
@@ -11705,8 +11747,10 @@ Function OutputDeliveryGroupCatalogs
 {
 	Param([object] $Group)
 	
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
-	$MCs = Get-BrokerDesktop @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.15 change from the deprecated Get-BrokerDesktop to Get-BrokerMachine and add -SortBy CatalogName
+	#$MCs = Get-BrokerDesktop @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName
+	$MCs = Get-BrokerMachine @XDParams2 -DesktopGroupUid $Group.Uid -Property CatalogName -SortBy CatalogName
 	
 	If($? -and $Null -ne $MCs)
 	{
@@ -11714,7 +11758,9 @@ Function OutputDeliveryGroupCatalogs
 		{
 			If($MCs.Count -gt 1)
 			{
-				[array]$MCs = $MCs | Sort-Object -Unique
+				#V2.15 fix the sort -unique. Only the first item in the array was being returned.
+				#Adding -Property CatalogName was needed to get the full unique array returned
+				[array]$MCs = $MCs | Sort-Object -Property CatalogName -Unique
 			}
 		}
 		
@@ -11739,7 +11785,7 @@ Function OutputDeliveryGroupCatalogs
 		{
 			Write-Verbose "$(Get-Date): `t`t`tAdding catalog $($MC.CatalogName)"
 
-			#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+			#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 			$Catalog = Get-BrokerCatalog @XDParams2 -Name $MC.CatalogName
 			If($? -and $Null -ne $Catalog)
 			{
@@ -12136,7 +12182,7 @@ Function OutputDeliveryGroupTags
 		$Tags = @()
 		ForEach($Tag in $GroupTags)
 		{
-			#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+			#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 			$Result = Get-BrokerTag @XDParams2 -Name $Tag
 			
 			If($? -and $Null -ne $Result)
@@ -12150,7 +12196,8 @@ Function OutputDeliveryGroupTags
 			}
 		}
 		
-		$Tags = $Tags | Sort-Object 
+		#V2.15 added -Property Name
+		$Tags = $Tags | Sort-Object -Property Name
 		
 		ForEach($Tag in $Tags)
 		{
@@ -12242,7 +12289,7 @@ Function OutputDeliveryGroupApplicationGroups
 		$rowdata = @()
 	}
 	
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 	$ApplicationGroups = Get-BrokerApplicationGroup @XDParams2 -AssociatedDesktopGroupUid $Group.Uid | Sort-Object Name
 	
 	If($? -and $Null -ne $ApplicationGroups)
@@ -12535,7 +12582,7 @@ Function OutputApplicationDetails
 	}
 	Else
 	{
-		$xVisibility = "Users inherited from Delivery Group"
+		$xVisibility = {Users inherited from Delivery Group}
 	}
 	
 	$DeliveryGroups = @()
@@ -12759,7 +12806,7 @@ Function OutputApplicationDetails
 			$cnt++
 			If($cnt -gt 0)
 			{
-				Line 5 "  " $xVisibility[$cnt]
+				Line 6 "  " $xVisibility[$cnt]
 			}
 		}
 		Line 1 "Application Path`t`t`t: " $Application.CommandLineExecutable
@@ -12779,7 +12826,7 @@ Function OutputApplicationDetails
 			$cnt++
 			If($cnt -gt 0)
 			{
-				Line 5 "  " $tmp
+				Line 6 "  " $tmp
 			}
 		}
 
@@ -12980,7 +13027,7 @@ Function OutputApplicationSessions
 		WriteHTMLLine 3 0 $txt
 	}
 
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 	$Sessions = Get-BrokerSession -ApplicationUid $Application.Uid @XDParams2 -SortBy UserName
 	
 	If($? -and $Null -ne $Sessions)
@@ -12999,8 +13046,10 @@ Function OutputApplicationSessions
 		{
 			#get desktop by Session Uid
 			$xMachineName = ""
-			#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
-			$Desktop = Get-BrokerDesktop -SessionUid $Session.Uid @XDParams2
+			#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
+			#V2.15 change from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+			#$Desktop = Get-BrokerDesktop -SessionUid $Session.Uid @XDParams2
+			$Desktop = Get-BrokerMachine -SessionUid $Session.Uid @XDParams2
 			
 			If($? -and $Null -ne $Desktop)
 			{
@@ -13252,7 +13301,7 @@ Function ProcessApplicationGroupDetails
 		WriteHTMLLine 1 0 $txt
 	}
 
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 	$ApplicationGroups = Get-BrokerApplicationGroup @XDParams2 -SortBy Name
 	
 	If($? -and $Null -ne $ApplicationGroups)
@@ -13561,8 +13610,9 @@ Function ProcessPolicies
 				Write-Verbose "$(Get-Date): "
 				Write-Verbose "$(Get-Date): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
 				Write-Verbose "$(Get-Date): "
-
-				[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -unique
+				
+				#V2.15 added -Property DisplayName
+				[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -Property DisplayName -unique
 				
 				ForEach($CtxGPO in $CtxGPOArray)
 				{
@@ -13660,7 +13710,8 @@ Function ProcessPolicySummary
 		$CtxGPOArray = GetCtxGPOsInAD
 		If($CtxGPOArray -is [Array] -and $CtxGPOArray.Count -gt 0)
 		{
-			[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -unique
+			#V2.15 added -Property DisplayName
+			[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -Property DisplayName -unique
 			Write-Verbose "$(Get-Date): "
 			Write-Verbose "$(Get-Date): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
 			Write-Verbose "$(Get-Date): "
@@ -27695,14 +27746,19 @@ Function OutputDatastores
 	
 	#24-Jun-2017 add Database Size to the output
 	#25-Jun-2017 add checking if the SQL Server assembly loaded before calculating the database size
+	
+	#V2.15 added get IP address for each SQL Server name
 	Write-Verbose "$(Get-Date): `tRetrieving database connection data"
 	Write-Verbose "$(Get-Date): `t`tConfiguration database"
-	$ConfigSQLServerPrincipalName = ""
-	$ConfigSQLServerMirrorName = "Not Configured"
-	$ConfigDatabaseName = ""
+	[string]$ConfigSQLServerPrincipalName = ""
+	[string]$ConfigSQLServerMirrorName = "Not Configured"
+	[string]$ConfigDatabaseName = ""
 	[string]$ConfigDBSize = "Unable to determine"
 	[string]$ConfigDBReadCommittedSnapshot = "Unable to determine"
 	[string]$ConfigDBSQLVersion = "Unable to determine"
+	[string]$ConfigSQLServerPrincipalNameIPAddress = ""
+	[string]$ConfigSQLServerMirrorNameIPAddress = ""
+	
 	$ConfigDBs = Get-ConfigDBConnection @XDParams1
 
 	If($? -and ($Null -ne $ConfigDBs))
@@ -27722,6 +27778,16 @@ Function OutputDatastores
 			}
 		}
 
+		$ConfigSQLServerPrincipalNameIPAddress = Get-IPAddress $ConfigSQLServerPrincipalName
+		If($ConfigSQLServerMirrorName -ne "Not Configured")
+		{
+			$ConfigSQLServerMirrorNameIPAddress = Get-IPAddress $ConfigSQLServerMirrorName
+		}
+		Else
+		{
+			$ConfigSQLServerMirrorNameIPAddress = "-"
+		}
+		
 		If($Script:SQLServerLoaded)
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
@@ -27776,19 +27842,23 @@ Function OutputDatastores
 			If($Configdb.IsMirroringEnabled)
 			{
 				$ConfigDBMirroringPartner			= $Configdb.MirroringPartner
+				$ConfigDBMirroringPartnerIPAddress	= Get-IPAddress $Configdb.MirroringPartner
 				$ConfigDBMirroringPartnerInstance	= $Configdb.MirroringPartnerInstance
 				$ConfigDBMirroringSafetyLevel		= $Configdb.MirroringSafetyLevel
 				$ConfigDBMirroringStatus			= $Configdb.MirroringStatus
 				$ConfigDBMirroringWitness			= $Configdb.MirroringWitness
+				$ConfigDBMirroringWitnessIPAddress	= Get-IPAddress $Configdb.MirroringWitness
 				$ConfigDBMirroringWitnessStatus		= $Configdb.MirroringWitnessStatus
 			}
 			Else
 			{
 				$ConfigDBMirroringPartner			= "-"
+				$ConfigDBMirroringPartnerIPAddress	= "-"
 				$ConfigDBMirroringPartnerInstance	= "-"
 				$ConfigDBMirroringSafetyLevel		= "-"
 				$ConfigDBMirroringStatus			= "-"
 				$ConfigDBMirroringWitness			= "-"
+				$ConfigDBMirroringWitnessIPAddress	= "-"
 				$ConfigDBMirroringWitnessStatus		= "-"
 			}
 			
@@ -27821,12 +27891,14 @@ Function OutputDatastores
 	}
 
 	Write-Verbose "$(Get-Date): `t`tConfiguration Logging database"
-	$LogSQLServerPrincipalName = ""
-	$LogSQLServerMirrorName = "Not Configured"
-	$LogDatabaseName = ""
+	[string]$LogSQLServerPrincipalName = ""
+	[string]$LogSQLServerMirrorName = "Not Configured"
+	[string]$LogDatabaseName = ""
 	[string]$LogDBSize = "Unable to determine"
 	[string]$LogDBReadCommittedSnapshot = "Unable to determine"
 	[string]$LogDBSQLVersion = "Unable to determine"
+	[string]$LogSQLServerPrincipalNameIPAddress = ""
+	[string]$LogSQLServerMirrorNameIPAddress = ""
 	$LogDBs = Get-LogDataStore @XDParams1
 
 	If($? -and ($Null -ne $LogDBs))
@@ -27852,6 +27924,16 @@ Function OutputDatastores
 			}
 		}
 
+		$LogSQLServerPrincipalNameIPAddress = Get-IPAddress $LogSQLServerPrincipalName
+		If($LogSQLServerMirrorName -ne "Not Configured")
+		{
+			$LogSQLServerMirrorNameIPAddress = Get-IPAddress $LogSQLServerMirrorName
+		}
+		Else
+		{
+			$LogSQLServerMirrorNameIPAddress = "-"
+		}
+		
 		If($Script:SQLServerLoaded)
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
@@ -27906,19 +27988,23 @@ Function OutputDatastores
 			If($LogDB.IsMirroringEnabled)
 			{
 				$LogDBMirroringPartner			= $LogDB.MirroringPartner
+				$LogDBMirroringPartnerIPAddress	= Get-IPAddress $Logdb.MirroringPartner
 				$LogDBMirroringPartnerInstance	= $LogDB.MirroringPartnerInstance
 				$LogDBMirroringSafetyLevel		= $LogDB.MirroringSafetyLevel
 				$LogDBMirroringStatus			= $LogDB.MirroringStatus
 				$LogDBMirroringWitness			= $LogDB.MirroringWitness
+				$LogDBMirroringWitnessIPAddress	= Get-IPAddress $Logdb.MirroringWitness
 				$LogDBMirroringWitnessStatus	= $LogDB.MirroringWitnessStatus
 			}
 			Else
 			{
 				$LogDBMirroringPartner			= "-"
+				$LogDBMirroringPartnerIPAddress	= "-"
 				$LogDBMirroringPartnerInstance	= "-"
 				$LogDBMirroringSafetyLevel		= "-"
 				$LogDBMirroringStatus			= "-"
 				$LogDBMirroringWitness			= "-"
+				$LogDBMirroringWitnessIPAddress	= "-"
 				$LogDBMirroringWitnessStatus	= "-"
 			}
 
@@ -27951,15 +28037,17 @@ Function OutputDatastores
 	}
 
 	Write-Verbose "$(Get-Date): `t`tMonitoring database"
-	$MonitorSQLServerPrincipalName = ""
-	$MonitorSQLServerMirrorName = "Not Configured"
-	$MonitorDatabaseName = ""
+	[string]$MonitorSQLServerPrincipalName = ""
+	[string]$MonitorSQLServerMirrorName = "Not Configured"
+	[string]$MonitorDatabaseName = ""
 	[string]$MonitorDBSize = "Unable to determine"
 	[string]$MonitorDBReadCommittedSnapshot = "Unable to determine"
 	[string]$MonitorDBSQLVersion = "Unable to determine"
-	$MonitorCollectHotfix = "Disabled"
-	$MonitorDataCollection = "Disabled"
-	$MonitorDetailedSQL = "Disabled"
+	[string]$MonitorCollectHotfix = "Disabled"
+	[string]$MonitorDataCollection = "Disabled"
+	[string]$MonitorDetailedSQL = "Disabled"
+	[string]$MonitorSQLServerPrincipalNameIPAddress = ""
+	[string]$MonitorSQLServerMirrorNameIPAddress = ""
 	
 	$MonitorDBs = Get-MonitorDataStore @XDParams1
 
@@ -27986,6 +28074,16 @@ Function OutputDatastores
 			}
 		}
 
+		$MonitorSQLServerPrincipalNameIPAddress = Get-IPAddress $MonitorSQLServerPrincipalName
+		If($MonitorSQLServerMirrorName -ne "Not Configured")
+		{
+			$MonitorSQLServerMirrorNameIPAddress = Get-IPAddress $MonitorSQLServerMirrorName
+		}
+		Else
+		{
+			$MonitorSQLServerMirrorNameIPAddress = "-"
+		}
+		
 		If($Script:SQLServerLoaded)
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerPrincipalName)")
@@ -28040,19 +28138,23 @@ Function OutputDatastores
 			If($MonitorDB.IsMirroringEnabled)
 			{
 				$MonitorDBMirroringPartner			= $MonitorDB.MirroringPartner
+				$MonitorDBMirroringPartnerIPAddress	= Get-IPAddress $Monitordb.MirroringPartner
 				$MonitorDBMirroringPartnerInstance	= $MonitorDB.MirroringPartnerInstance
 				$MonitorDBMirroringSafetyLevel		= $MonitorDB.MirroringSafetyLevel
 				$MonitorDBMirroringStatus			= $MonitorDB.MirroringStatus
 				$MonitorDBMirroringWitness			= $MonitorDB.MirroringWitness
+				$MonitorDBMirroringWitnessIPAddress	= Get-IPAddress $Monitordb.MirroringWitness
 				$MonitorDBMirroringWitnessStatus	= $MonitorDB.MirroringWitnessStatus
 			}
 			Else
 			{
 				$MonitorDBMirroringPartner			= "-"
+				$MonitorDBMirroringPartnerIPAddress	= "-"
 				$MonitorDBMirroringPartnerInstance	= "-"
 				$MonitorDBMirroringSafetyLevel		= "-"
 				$MonitorDBMirroringStatus			= "-"
 				$MonitorDBMirroringWitness			= "-"
+				$MonitorDBMirroringWitnessIPAddress	= "-"
 				$MonitorDBMirroringWitnessStatus	= "-"
 			}
 
@@ -28133,16 +28235,20 @@ Function OutputDatastores
 		$ScriptInformation += @{Data = "Last Backup Date"; Value = $ConfigDBLastBackupDate; }
 		$ScriptInformation += @{Data = "Last Log Backup Date"; Value = $ConfigDBLastLogBackupDate; }
 		$ScriptInformation += @{Data = "Mirror Server Address"; Value = $ConfigSQLServerMirrorName; }
+		$ScriptInformation += @{Data = "Mirror Server IP Address"; Value = $ConfigSQLServerMirrorNameIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner"; Value = $ConfigDBMirroringPartner; }
+		$ScriptInformation += @{Data = "Mirroring Partner IP Address"; Value = $ConfigDBMirroringPartnerIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner Instance"; Value = $ConfigDBMirroringPartnerInstance; }
 		$ScriptInformation += @{Data = "Mirroring Safety Level"; Value = $ConfigDBMirroringSafetyLevel; }
 		$ScriptInformation += @{Data = "Mirroring Status"; Value = $ConfigDBMirroringStatus; }
 		$ScriptInformation += @{Data = "Mirroring Witness"; Value = $ConfigDBMirroringWitness; }
+		$ScriptInformation += @{Data = "Mirroring Witness IP Address"; Value = $ConfigDBMirroringWitnessIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Witness Status"; Value = $ConfigDBMirroringWitnessStatus; }
 		$ScriptInformation += @{Data = "Parent"; Value = $ConfigDBParent; }
 		$ScriptInformation += @{Data = "Read-Committed Snapshot"; Value = $ConfigDBReadCommittedSnapshot; }
 		$ScriptInformation += @{Data = "Recovery Model"; Value = $ConfigDBRecoveryModel; }
 		$ScriptInformation += @{Data = "Server Address"; Value = $ConfigSQLServerPrincipalName; }
+		$ScriptInformation += @{Data = "Server IP Address"; Value = $ConfigSQLServerPrincipalNameIPAddress; }
 		$ScriptInformation += @{Data = "SQL Server Version"; Value = $ConfigDBSQLVersion; }
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -28172,17 +28278,21 @@ Function OutputDatastores
 		$ScriptInformation += @{Data = "Database Size"; Value = $LogDBSize; }
 		$ScriptInformation += @{Data = "Last Backup Date"; Value = $LogDBLastBackupDate; }
 		$ScriptInformation += @{Data = "Last Log Backup Date"; Value = $LogDBLastLogBackupDate; }
-		$ScriptInformation += @{Data = "Mirror Server Address"; Value = $ConfigSQLServerMirrorName; }
+		$ScriptInformation += @{Data = "Mirror Server Address"; Value = $LogSQLServerMirrorName; }
+		$ScriptInformation += @{Data = "Mirror Server IP Address"; Value = $LogSQLServerMirrorNameIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner"; Value = $LogDBMirroringPartner; }
+		$ScriptInformation += @{Data = "Mirroring Partner IP Address"; Value = $LogDBMirroringPartnerIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner Instance"; Value = $LogDBMirroringPartnerInstance; }
 		$ScriptInformation += @{Data = "Mirroring Safety Level"; Value = $LogDBMirroringSafetyLevel; }
 		$ScriptInformation += @{Data = "Mirroring Status"; Value = $LogDBMirroringStatus; }
 		$ScriptInformation += @{Data = "Mirroring Witness"; Value = $LogDBMirroringWitness; }
+		$ScriptInformation += @{Data = "Mirroring Witness IP Address"; Value = $LogDBMirroringWitnessIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Witness Status"; Value = $LogDBMirroringWitnessStatus; }
 		$ScriptInformation += @{Data = "Parent"; Value = $LogDBParent; }
 		$ScriptInformation += @{Data = "Read-Committed Snapshot"; Value = $LogDBReadCommittedSnapshot; }
 		$ScriptInformation += @{Data = "Recovery Model"; Value = $LogDBRecoveryModel; }
 		$ScriptInformation += @{Data = "Server Address"; Value = $LogSQLServerPrincipalName; }
+		$ScriptInformation += @{Data = "Server IP Address"; Value = $LogSQLServerPrincipalNameIPAddress; }
 		$ScriptInformation += @{Data = "SQL Server Version"; Value = $LogDBSQLVersion; }
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -28212,17 +28322,21 @@ Function OutputDatastores
 		$ScriptInformation += @{Data = "Database Size"; Value = $MonitorDBSize; }
 		$ScriptInformation += @{Data = "Last Backup Date"; Value = $MonitorDBLastBackupDate; }
 		$ScriptInformation += @{Data = "Last Log Backup Date"; Value = $MonitorDBLastLogBackupDate; }
-		$ScriptInformation += @{Data = "Mirror Server Address"; Value = $ConfigSQLServerMirrorName; }
+		$ScriptInformation += @{Data = "Mirror Server Address"; Value = $MonitorSQLServerMirrorName; }
+		$ScriptInformation += @{Data = "Mirror Server IP Address"; Value = $MonitorSQLServerMirrorNameIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner"; Value = $MonitorDBMirroringPartner; }
+		$ScriptInformation += @{Data = "Mirroring Partner IP Address"; Value = $MonitorDBMirroringPartnerIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Partner Instance"; Value = $MonitorDBMirroringPartnerInstance; }
 		$ScriptInformation += @{Data = "Mirroring Safety Level"; Value = $MonitorDBMirroringSafetyLevel; }
 		$ScriptInformation += @{Data = "Mirroring Status"; Value = $MonitorDBMirroringStatus; }
 		$ScriptInformation += @{Data = "Mirroring Witness"; Value = $MonitorDBMirroringWitness; }
+		$ScriptInformation += @{Data = "Mirroring Witness IP Address"; Value = $MonitorDBMirroringWitnessIPAddress; }
 		$ScriptInformation += @{Data = "Mirroring Witness Status"; Value = $MonitorDBMirroringWitnessStatus; }
 		$ScriptInformation += @{Data = "Parent"; Value = $MonitorDBParent; }
 		$ScriptInformation += @{Data = "Read-Committed Snapshot"; Value = $MonitorDBReadCommittedSnapshot; }
 		$ScriptInformation += @{Data = "Recovery Model"; Value = $MonitorDBRecoveryModel; }
 		$ScriptInformation += @{Data = "Server Address"; Value = $MonitorSQLServerPrincipalName; }
+		$ScriptInformation += @{Data = "Server IP Address"; Value = $MonitorSQLServerPrincipalNameIPAddress; }
 		$ScriptInformation += @{Data = "SQL Server Version"; Value = $MonitorDBSQLVersion; }
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -28383,16 +28497,20 @@ Function OutputDatastores
 		Line 2 "Last Backup Date`t`t`t`t: " $ConfigDBLastBackupDate
 		Line 2 "Last Log Backup Date`t`t`t`t: " $ConfigDBLastLogBackupDate
 		Line 2 "Mirror Server Address`t`t`t`t: " $ConfigSQLServerMirrorName
+		Line 2 "Mirror Server IP Address`t`t`t: " $ConfigSQLServerMirrorNameIPAddress
 		Line 2 "Mirroring Partner`t`t`t`t: " $ConfigDBMirroringPartner
+		Line 2 "Mirroring Partner IP Address`t`t`t: " $ConfigDBMirroringPartnerIPAddress
 		Line 2 "Mirroring Partner Instance`t`t`t: " $ConfigDBMirroringPartnerInstance
 		Line 2 "Mirroring Safety Level`t`t`t`t: " $ConfigDBMirroringSafetyLevel
 		Line 2 "Mirroring Status`t`t`t`t: " $ConfigDBMirroringStatus
 		Line 2 "Mirroring Witness`t`t`t`t: " $ConfigDBMirroringWitness
+		Line 2 "Mirroring Witness IP Address`t`t`t: " $ConfigDBMirroringWitnessIPAddress
 		Line 2 "Mirroring Witness Status`t`t`t: " $ConfigDBMirroringWitnessStatus
 		Line 2 "Parent`t`t`t`t`t`t: " $ConfigDBParent
 		Line 2 "Read-Committed Snapshot`t`t`t`t: " $ConfigDBReadCommittedSnapshot
 		Line 2 "Recovery Model`t`t`t`t`t: " $ConfigDBRecoveryModel
 		Line 2 "Server Address`t`t`t`t`t: " $ConfigSQLServerPrincipalName
+		Line 2 "Server IP Address`t`t`t`t: " $ConfigSQLServerPrincipalNameIPAddress
 		Line 2 "SQL Server Version`t`t`t`t: " $ConfigDBSQLVersion
 		Line 0 ""
 		Line 1 "Datastore: Logging"
@@ -28406,16 +28524,20 @@ Function OutputDatastores
 		Line 2 "Last Backup Date`t`t`t`t: " $LogDBLastBackupDate
 		Line 2 "Last Log Backup Date`t`t`t`t: " $LogDBLastLogBackupDate
 		Line 2 "Mirror Server Address`t`t`t`t: " $LogSQLServerMirrorName
+		Line 2 "Mirror Server IP Address`t`t`t: " $LogSQLServerMirrorNameIPAddress
 		Line 2 "Mirroring Partner`t`t`t`t: " $LogDBMirroringPartner
+		Line 2 "Mirroring Partner IP Address`t`t`t: " $LogDBMirroringPartnerIPAddress
 		Line 2 "Mirroring Partner Instance`t`t`t: " $LogDBMirroringPartnerInstance
 		Line 2 "Mirroring Safety Level`t`t`t`t: " $LogDBMirroringSafetyLevel
 		Line 2 "Mirroring Status`t`t`t`t: " $LogDBMirroringStatus
 		Line 2 "Mirroring Witness`t`t`t`t: " $LogDBMirroringWitness
+		Line 2 "Mirroring Witness IP Address`t`t`t: " $LogDBMirroringWitnessIPAddress
 		Line 2 "Mirroring Witness Status`t`t`t: " $LogDBMirroringWitnessStatus
 		Line 2 "Parent`t`t`t`t`t`t: " $LogDBParent
 		Line 2 "Read-Committed Snapshot`t`t`t`t: " $LogDBReadCommittedSnapshot
 		Line 2 "Recovery Model`t`t`t`t`t: " $LogDBRecoveryModel
 		Line 2 "Server Address`t`t`t`t`t: " $LogSQLServerPrincipalName
+		Line 2 "Server IP Address`t`t`t`t: " $LogSQLServerPrincipalNameIPAddress
 		Line 2 "SQL Server Version`t`t`t`t: " $LogDBSQLVersion
 		Line 0 ""
 		Line 1 "Datastore: Monitoring"
@@ -28429,16 +28551,20 @@ Function OutputDatastores
 		Line 2 "Last Backup Date`t`t`t`t: " $MonitorDBLastBackupDate
 		Line 2 "Last Log Backup Date`t`t`t`t: " $MonitorDBLastLogBackupDate
 		Line 2 "Mirror Server Address`t`t`t`t: " $MonitorSQLServerMirrorName
+		Line 2 "Mirror Server IP Address`t`t`t: " $MonitorSQLServerMirrorNameIPAddress
 		Line 2 "Mirroring Partner`t`t`t`t: " $MonitorDBMirroringPartner
+		Line 2 "Mirroring Partner IP Address`t`t`t: " $MonitorDBMirroringPartnerIPAddress
 		Line 2 "Mirroring Partner Instance`t`t`t: " $MonitorDBMirroringPartnerInstance
 		Line 2 "Mirroring Safety Level`t`t`t`t: " $MonitorDBMirroringSafetyLevel
 		Line 2 "Mirroring Status`t`t`t`t: " $MonitorDBMirroringStatus
 		Line 2 "Mirroring Witness`t`t`t`t: " $MonitorDBMirroringWitness
+		Line 2 "Mirroring Witness IP Address`t`t`t: " $MonitorDBMirroringWitnessIPAddress
 		Line 2 "Mirroring Witness Status`t`t`t: " $MonitorDBMirroringWitnessStatus
 		Line 2 "Parent`t`t`t`t`t`t: " $MonitorDBParent
 		Line 2 "Read-Committed Snapshot`t`t`t`t: " $MonitorDBReadCommittedSnapshot
 		Line 2 "Recovery Model`t`t`t`t`t: " $MonitorDBRecoveryModel
 		Line 2 "Server Address`t`t`t`t`t: " $MonitorSQLServerPrincipalName
+		Line 2 "Server IP Address`t`t`t`t: " $MonitorSQLServerPrincipalNameIPAddress
 		Line 2 "SQL Server Version`t`t`t`t: " $MonitorDBSQLVersion
 		Line 0 ""
 
@@ -28553,16 +28679,20 @@ Function OutputDatastores
 		$rowdata += @(,("Last Backup Date",($htmlsilver -bor $htmlbold),$ConfigDBLastBackupDate,$htmlwhite))
 		$rowdata += @(,("Last Log Backup Date",($htmlsilver -bor $htmlbold),$ConfigDBLastLogBackupDate,$htmlwhite))
 		$rowdata += @(,("Mirror Server Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerMirrorName,$htmlwhite))
+		$rowdata += @(,("Mirror Server IP Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerMirrorNameIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner",($htmlsilver -bor $htmlbold),$ConfigDBMirroringPartner,$htmlwhite))
+		$rowdata += @(,("Mirroring Partner IP Address",($htmlsilver -bor $htmlbold),$ConfigDBMirroringPartnerIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner Instance",($htmlsilver -bor $htmlbold),$ConfigDBMirroringPartnerInstance,$htmlwhite))
 		$rowdata += @(,("Mirroring Safety Level",($htmlsilver -bor $htmlbold),$ConfigDBMirroringSafetyLevel,$htmlwhite))
 		$rowdata += @(,("Mirroring Status",($htmlsilver -bor $htmlbold),$ConfigDBMirroringStatus,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness",($htmlsilver -bor $htmlbold),$ConfigDBMirroringWitness,$htmlwhite))
+		$rowdata += @(,("Mirroring Witness IP Address",($htmlsilver -bor $htmlbold),$ConfigDBMirroringWitnessIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness Status",($htmlsilver -bor $htmlbold),$ConfigDBMirroringWitnessStatus,$htmlwhite))
 		$rowdata += @(,("Parent",($htmlsilver -bor $htmlbold),$ConfigDBParent,$htmlwhite))
 		$rowdata += @(,("Read-Committed Snapshot",($htmlsilver -bor $htmlbold),$ConfigDBReadCommittedSnapshot,$htmlwhite))
 		$rowdata += @(,("Recovery Model",($htmlsilver -bor $htmlbold),$ConfigDBRecoveryModel,$htmlwhite))
 		$rowdata += @(,("Server Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerPrincipalName,$htmlwhite))
+		$rowdata += @(,("Server IP Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerPrincipalNameIPAddress,$htmlwhite))
 		$rowdata += @(,("SQL Server Version",($htmlsilver -bor $htmlbold),$ConfigDBSQLVersion,$htmlwhite))
 		$msg = ""
 		$columnWidths = @("250","200")
@@ -28580,17 +28710,21 @@ Function OutputDatastores
 		$rowdata += @(,("Database Size",($htmlsilver -bor $htmlbold),$LogDBSize,$htmlwhite))
 		$rowdata += @(,("Last Backup Date",($htmlsilver -bor $htmlbold),$LogDBLastBackupDate,$htmlwhite))
 		$rowdata += @(,("Last Log Backup Date",($htmlsilver -bor $htmlbold),$LogDBLastLogBackupDate,$htmlwhite))
-		$rowdata += @(,("Mirror Server Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerMirrorName,$htmlwhite))
+		$rowdata += @(,("Mirror Server Address",($htmlsilver -bor $htmlbold),$LogSQLServerMirrorName,$htmlwhite))
+		$rowdata += @(,("Mirror Server IP Address",($htmlsilver -bor $htmlbold),$LogSQLServerMirrorNameIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner",($htmlsilver -bor $htmlbold),$LogDBMirroringPartner,$htmlwhite))
+		$rowdata += @(,("Mirroring Partner IP Address",($htmlsilver -bor $htmlbold),$LogDBMirroringPartnerIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner Instance",($htmlsilver -bor $htmlbold),$LogDBMirroringPartnerInstance,$htmlwhite))
 		$rowdata += @(,("Mirroring Safety Level",($htmlsilver -bor $htmlbold),$LogDBMirroringSafetyLevel,$htmlwhite))
 		$rowdata += @(,("Mirroring Status",($htmlsilver -bor $htmlbold),$LogDBMirroringStatus,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness",($htmlsilver -bor $htmlbold),$LogDBMirroringWitness,$htmlwhite))
+		$rowdata += @(,("Mirroring Witness IP Address",($htmlsilver -bor $htmlbold),$LogDBMirroringWitnessIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness Status",($htmlsilver -bor $htmlbold),$LogDBMirroringWitnessStatus,$htmlwhite))
 		$rowdata += @(,("Parent",($htmlsilver -bor $htmlbold),$LogDBParent,$htmlwhite))
 		$rowdata += @(,("Read-Committed Snapshot",($htmlsilver -bor $htmlbold),$LogDBReadCommittedSnapshot,$htmlwhite))
 		$rowdata += @(,("Recovery Model",($htmlsilver -bor $htmlbold),$LogDBRecoveryModel,$htmlwhite))
 		$rowdata += @(,("Server Address",($htmlsilver -bor $htmlbold),$LogSQLServerPrincipalName,$htmlwhite))
+		$rowdata += @(,("Server IP Address",($htmlsilver -bor $htmlbold),$LogSQLServerPrincipalNameIPAddress,$htmlwhite))
 		$rowdata += @(,("SQL Server Version",($htmlsilver -bor $htmlbold),$LogDBSQLVersion,$htmlwhite))
 		$msg = ""
 		$columnWidths = @("250","200")
@@ -28608,17 +28742,21 @@ Function OutputDatastores
 		$rowdata += @(,("Database Size",($htmlsilver -bor $htmlbold),$MonitorDBSize,$htmlwhite))
 		$rowdata += @(,("Last Backup Date",($htmlsilver -bor $htmlbold),$MonitorDBLastBackupDate,$htmlwhite))
 		$rowdata += @(,("Last Log Backup Date",($htmlsilver -bor $htmlbold),$MonitorDBLastLogBackupDate,$htmlwhite))
-		$rowdata += @(,("Mirror Server Address",($htmlsilver -bor $htmlbold),$ConfigSQLServerMirrorName,$htmlwhite))
+		$rowdata += @(,("Mirror Server Address",($htmlsilver -bor $htmlbold),$MonitorSQLServerMirrorName,$htmlwhite))
+		$rowdata += @(,("Mirror Server IP Address",($htmlsilver -bor $htmlbold),$MonitorSQLServerMirrorNameIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner",($htmlsilver -bor $htmlbold),$MonitorDBMirroringPartner,$htmlwhite))
+		$rowdata += @(,("Mirroring Partner IP Address",($htmlsilver -bor $htmlbold),$MonitorDBMirroringPartnerIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Partner Instance",($htmlsilver -bor $htmlbold),$MonitorDBMirroringPartnerInstance,$htmlwhite))
 		$rowdata += @(,("Mirroring Safety Level",($htmlsilver -bor $htmlbold),$MonitorDBMirroringSafetyLevel,$htmlwhite))
 		$rowdata += @(,("Mirroring Status",($htmlsilver -bor $htmlbold),$MonitorDBMirroringStatus,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness",($htmlsilver -bor $htmlbold),$MonitorDBMirroringWitness,$htmlwhite))
+		$rowdata += @(,("Mirroring Witness IP Address",($htmlsilver -bor $htmlbold),$MonitorDBMirroringWitnessIPAddress,$htmlwhite))
 		$rowdata += @(,("Mirroring Witness Status",($htmlsilver -bor $htmlbold),$MonitorDBMirroringWitnessStatus,$htmlwhite))
 		$rowdata += @(,("Parent",($htmlsilver -bor $htmlbold),$MonitorDBParent,$htmlwhite))
 		$rowdata += @(,("Read-Committed Snapshot",($htmlsilver -bor $htmlbold),$MonitorDBReadCommittedSnapshot,$htmlwhite))
 		$rowdata += @(,("Recovery Model",($htmlsilver -bor $htmlbold),$MonitorDBRecoveryModel,$htmlwhite))
 		$rowdata += @(,("Server Address",($htmlsilver -bor $htmlbold),$MonitorSQLServerPrincipalName,$htmlwhite))
+		$rowdata += @(,("Server IP Address",($htmlsilver -bor $htmlbold),$MonitorSQLServerPrincipalNameIPAddress,$htmlwhite))
 		$rowdata += @(,("SQL Server Version",($htmlsilver -bor $htmlbold),$MonitorDBSQLVersion,$htmlwhite))
 		$msg = ""
 		$columnWidths = @("250","200")
@@ -30591,7 +30729,7 @@ Function OutputControllerRegistryKeys
 			}
 			ElseIf($Text)
 			{
-				Line 1 ( "{0,-50} {1,-77} {2,-15}" -f $Item.RegKey, $Item.RegValue, $Item.Value)
+				Line 1 ( "{0,-77} {1,-50} {2,-15}" -f $Item.RegKey, $Item.RegValue, $Item.Value)
 			}
 			ElseIf($HTML)
 			{
@@ -30717,7 +30855,7 @@ Function ProcessHosting
 	}
 
 	Write-Verbose "$(Get-Date): `tProcessing Hypervisors"
-	#V2.10 22-jan=2018 change from xdparams1 to xdparams2 to add maxrecordcount
+	#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
 	$Hypervisors = Get-BrokerHypervisorConnection @XDParams2
 	If($? -and $Null -ne $Hypervisors)
 	{
@@ -30822,7 +30960,7 @@ Function OutputHosting
 {
 	Param([object] $Hypervisor, [string] $xConnectionType, [string] $xAddress, [string] $xState, [string] $xUserName, [bool] $xMaintMode, [string] $xStorageName, [array] $xHAAddress, [array]$xPowerActions, [string] $xScopes, [string] $xZoneName)
 
-	$xHAAddress = $xHAAddress | Sort-Object
+	$xHAAddress = $xHAAddress | Sort-Object 
 	
 	$xxConnectionType = ""
 	Switch ($xConnectionType)
@@ -31513,7 +31651,9 @@ Function OutputHostingSessions
 		#get desktop by Session Uid
 		$xMachineName = ""
 		#V2.10 22-jan-2018 change from xdparams1 to xdparams2 to add maxrecordcount
-		$Desktop = Get-BrokerDesktop -SessionUid $Session.Uid @XDParams2
+		#V2.15 change from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+		#$Desktop = Get-BrokerDesktop -SessionUid $Session.Uid @XDParams2
+		$Desktop = Get-BrokerMachine -SessionUid $Session.Uid @XDParams2
 		
 		If($? -and $Null -ne $Desktop)
 		{
@@ -31650,6 +31790,10 @@ Function ProcessLicensing
 Function OutputLicensingOverview
 {
 	Write-Verbose "$(Get-Date): `tOutput Licensing Overview"
+
+	#V2.15 added getting the IP address for the license server
+	$LicenseServerIPAddress = Get-IPAddress $Script:XDSite1.LicenseServerName
+	
 	$LicenseEditionType = ""
 	$LicenseModelType = ""
 
@@ -31694,6 +31838,7 @@ Function OutputLicensingOverview
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{Data = "Site"; Value = $Script:XDSite1.Name; }
 		$ScriptInformation += @{Data = "Server"; Value = $Script:XDSite1.LicenseServerName; }
+		$ScriptInformation += @{Data = "IP Address"; Value = $LicenseServerIPAddress; }
 		$ScriptInformation += @{Data = "Port"; Value = $Script:XDSite1.LicenseServerPort; }
 		$ScriptInformation += @{Data = "Edition"; Value = $LicenseEditionType; }
 		$ScriptInformation += @{Data = "License model"; Value = $LicenseModelType; }
@@ -31722,6 +31867,7 @@ Function OutputLicensingOverview
 		Line 0 ""
 		Line 0 "Site`t`t`t: " $Script:XDSite1.Name
 		Line 0 "Server`t`t`t: " $Script:XDSite1.LicenseServerName
+		Line 0 "IP Address`t`t: " $LicenseServerIPAddress
 		Line 0 "Port`t`t`t: " $Script:XDSite1.LicenseServerPort
 		Line 0 "Edition`t`t`t: " $LicenseEditionType
 		Line 0 "License model`t`t: " $LicenseModelType
@@ -31736,6 +31882,7 @@ Function OutputLicensingOverview
 		$rowdata = @()
 		$columnHeaders = @("Site",($htmlsilver -bor $htmlbold),$Script:XDSite1.Name,$htmlwhite)
 		$rowdata += @(,('Server',($htmlsilver -bor $htmlbold),$Script:XDSite1.LicenseServerName,$htmlwhite))
+		$rowdata += @(,("IP Address",($htmlsilver -bor $htmlbold),$LicenseServerIPAddress,$htmlwhite))
 		$rowdata += @(,('Port',($htmlsilver -bor $htmlbold),$Script:XDSite1.LicenseServerPort,$htmlwhite))
 		$rowdata += @(,('Edition',($htmlsilver -bor $htmlbold),$LicenseEditionType,$htmlwhite))
 		$rowdata += @(,('License model',($htmlsilver -bor $htmlbold),$LicenseModelType,$htmlwhite))
@@ -32127,7 +32274,7 @@ Function OutputStoreFrontDeliveryGroups
 		}
 	}
 
-	[array]$DeliveryGroups = $DeliveryGroups | Sort-Object
+	[array]$DeliveryGroups = $DeliveryGroups | Sort-Object Name
 	
 	If($MSWord -or $PDF)
 	{

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -75,11 +75,11 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid346080\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2579094\rsid2584542\rsid2902416\rsid2978753
-\rsid3300860\rsid3430394\rsid3761251\rsid3830441\rsid4149699\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7733837\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866
-\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12602409\rsid12801149\rsid12863195\rsid13437246\rsid13662136\rsid13853169
-\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy11\hr6\min36}{\version48}{\edmins11778}{\nofpages26}{\nofwords8561}
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid219208\rsid265763\rsid346080\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2579094\rsid2584542\rsid2902416
+\rsid2978753\rsid3300860\rsid3430394\rsid3761251\rsid3830441\rsid4149699\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7733837\rsid7763859\rsid8394203\rsid8410782\rsid8662784\rsid8876191
+\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12602409\rsid12801149\rsid12863195\rsid13437246\rsid13662136
+\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0
+\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy16\hr6\min45}{\version49}{\edmins11778}{\nofpages26}{\nofwords8561}
 {\nofchars48801}{\nofcharsws57248}{\vern55}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -192,8 +192,9 @@ PVS PowerShell SDK x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c07000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 
-https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
+\hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -231,7 +232,7 @@ WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  H\hich\af37\dbch\af31505\loch\f37 
 YPERLINK "http://support.citrix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c0048}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 .  The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 
 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 
@@ -1019,7 +1020,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1027,19 +1028,19 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -D\hich\af2\dbch\af31505\loch\f2 ev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file\hich\af2\dbch\af31505\loch\f2  is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is pl\hich\af2\dbch\af31505\loch\f2 aced in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
@@ -1080,10 +1081,11 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15802422 \hich\af2\dbch\af31505\loch\f2         VERSION: 2.14}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7733837\charrsid7733837 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2243781 \hich\af2\dbch\af31505\loch\f2         VERSION: 2.15}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7733837\charrsid7733837 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12271374 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16527420 \hich\af2\dbch\af31505\loch\f2 11}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12271374 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7733837\charrsid7733837 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12271374 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16527420 \hich\af2\dbch\af31505\loch\f2 1}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2243781 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12271374 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7733837\charrsid7733837 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1823,10 +1825,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000009032
-b64c89d1d30103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff0200000000000000000000000000000000000000000000009032b64c89d1d301
-9032b64c89d1d30100000000000000000000000054004200c500ce005200df00d500c600d0004500ce00c100db004d00d300c80041004a00c800de003000c0003d003d000000000000000000000000000000000032000101ffffffffffffffff0300000000000000000000000000000000000000000000009032b64c89d1
-d3019032b64c89d1d3010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000b052
+856378d5d30103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000b052856378d5d301
+b052856378d5d301000000000000000000000000cc003500560059005a00c300d10044005000c400ca004c00c600d5004700d700dd00c7004b00cc00dd0041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000b052856378d5
+d301b052856378d5d3010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1834,7 +1836,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b34373645313934432d363646442d344243302d413145432d4343453830303941334536417d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b36363538463542312d343333432d344133452d384239422d3531423746363732414346347d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,18 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.15 16-Apr-2018
+#	Added Function Get-IPAddress
+#	Added in Function OutputDatastores getting the IP address for each SQL server name
+#	Added in Function OutputLicensingOverview getting the IP address for the license server
+#	Changed from the deprecated Get-BrokerDesktop to Get-BrokerMachine
+#	Fixed many alignment issues with Text output
+#	In the Desktop Entitlement section, Excluded Users, the wrong variable name was used. Fixed.
+#	When building the array of all Machine Catalogs that are used by a Delivery Group,
+#		Only the first item in the array was being returned. Adding -Property CatalogName 
+#		to Sort-Object was needed to get the full unique array returned.
+#		Sort-Object -Property CatalogName -Unique
+
 #Version 2.14 11-Apr-2018
 #	Added the following properties to Application Details
 #		Application Type


### PR DESCRIPTION
#Version 2.15 16-Apr-2018
#	Added Function Get-IPAddress
#	Added in Function OutputDatastores getting the IP address for each SQL server name
#	Added in Function OutputLicensingOverview getting the IP address for the license server
#	Changed from the deprecated Get-BrokerDesktop to Get-BrokerMachine
#	Fixed many alignment issues with Text output
#	In the Desktop Entitlement section, Excluded Users, the wrong variable name was used. Fixed.
#	When building the array of all Machine Catalogs that are used by a Delivery Group,
#		Only the first item in the array was being returned. Adding -Property CatalogName 
#		to Sort-Object was needed to get the full unique array returned.
#		Sort-Object -Property CatalogName -Unique