### PR TITLE
V2.21

### DIFF
--- a/2.20.2ReadMe.md
+++ b/2.20.2ReadMe.md
@@ -1,2 +1,0 @@
-#Version 2.20.2 26-Dec-2018
-#	Fixed Function OutputAppendixA to fix duplicate VDA registry lines

--- a/2.21ReadMe.md
+++ b/2.21ReadMe.md
@@ -1,0 +1,12 @@
+#Version 2.21
+#	Added License Server version
+#	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
+#	Added test to catch multiple output parameters used
+#	Added the restart schedule "Frequency notification" to Delivery Group details
+#	Changed in Function Get-IPAddress, the Catch value from $Null to "Unable to resolve IP address"
+#	Fixed, in Functions OutputDesktopOSMachine and OutputServerOSMachine, the output of users
+#	Fixed bug in Function ProcessHosting where the comparison for $Hypervisor.Name was done incorrectly
+#	Fixed in Delivery Groups details to handle multiple Desktop Entitlements and multiple Restart Schedules
+#	Fixed in Function OutputControllerRegistryKeys, added a blank line after the Word table
+#	For Application details changed "Description" to "Description and keywords"
+#	In the Delivery Controllers section added a blank line after the Word and HTML tables

--- a/2.21ReadMe.md
+++ b/2.21ReadMe.md
@@ -1,4 +1,7 @@
-#Version 2.21
+#Version 2.21 1-Feb-2019
+#	Added additional VDA registry key data to Machine details for Local Text Echo added back in VDA 1811
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\UseDirect3D
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\PresentDevice
 #	Added License Server version
 #	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
 #	Added test to catch multiple output parameters used

--- a/README.md
+++ b/README.md
@@ -936,10 +936,21 @@ OUTPUTS
     This script creates a Word, PDF, plain text, or HTML document.
 
 NOTES
-        NAME: XD7_Inventory_V2.ps1
-        VERSION: 2.21
-        AUTHOR: Carl Webster
-        LASTEDIT: January 26, 2019
+        NAME: 
+	
+	XD7_Inventory_V2.ps1
+        
+	VERSION: 
+	
+	2.21
+        
+	AUTHOR: 
+	
+	Carl Webster
+        
+	LASTEDIT: 
+	
+	January 26, 2019
 
     -------------------------- EXAMPLE 1 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ SYNOPSIS
     Creates an inventory of a Citrix XenDesktop 7.8+ Site.
 
 SYNTAX
+
     C:\Scripts\XD7_Inventory_V2.ps1 [-MSWord] [-AddDateTime] [-AdminAddress 
     <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
     [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] 

--- a/README.md
+++ b/README.md
@@ -936,21 +936,15 @@ OUTPUTS
     This script creates a Word, PDF, plain text, or HTML document.
 
 NOTES
-        NAME: 
-	
-	XD7_Inventory_V2.ps1
+
+        NAME: 	XD7_Inventory_V2.ps1
         
-	VERSION: 
-	
-	2.21
+	VERSION: 2.21
         
-	AUTHOR: 
-	
-	Carl Webster
+	AUTHOR: Carl Webster
         
-	LASTEDIT: 
+	LASTEDIT: January 26, 2019
 	
-	January 26, 2019
 
     -------------------------- EXAMPLE 1 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -937,12 +937,12 @@ OUTPUTS
 
 NOTES
 
-        NAME: 	XD7_Inventory_V2.ps1
-        
+	NAME: 	XD7_Inventory_V2.ps1
+
 	VERSION: 2.21
-        
+
 	AUTHOR: Carl Webster
-        
+
 	LASTEDIT: January 26, 2019
 	
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ The help text explains all the parameters the script accepts.
 PS C:\Scripts> get-help .\XD7_Inventory_V2.ps1 -full
 
 NAME
+
     C:\Scripts\XD7_Inventory_V2.ps1
 
 SYNOPSIS
+
     Creates an inventory of a Citrix XenDesktop 7.8+ Site.
 
 SYNTAX
@@ -205,6 +207,7 @@ SYNTAX
 
 
 DESCRIPTION
+
     Creates an inventory of a Citrix XenDesktop 7.8+ Site using Microsoft PowerShell, Word,
     plain text, or HTML.
 
@@ -274,6 +277,7 @@ DESCRIPTION
 
 
 PARAMETERS
+
     -HTML [<SwitchParameter>]
         Creates an HTML file with an .html extension.
         This parameter is disabled by default.
@@ -922,10 +926,12 @@ PARAMETERS
         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 
 INPUTS
+
     None.  You cannot pipe objects to this script.
 
 
 OUTPUTS
+
     No objects are output from this script.
     This script creates a Word, PDF, plain text, or HTML document.
 

--- a/README.md
+++ b/README.md
@@ -148,1345 +148,1501 @@ The help text explains all the parameters the script accepts.
 
 ## Help Text
 
-	PS C:\Scripts> get-help .\XD7_Inventory_V2.ps1 -full
-	
-	NAME
-	    C:\Scripts\XD7_Inventory_V2.ps1
-	
-	SYNOPSIS
-	    Creates an inventory of a Citrix XenDesktop 7.8+ Site.
-	
-	SYNTAX
-	    C:\Scripts\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] 
-	    [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] 
-	    [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] 
-	    [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
-	    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate 
-	    <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] 
-	    [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] 
-	    [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
-	
-	    C:\Scripts\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] 
-	    [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] 
-	    [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] 
-	    [-PDF] [-Text] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
-	    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate 
-	    <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] 
-	    [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] 
-	    [-Hardware] [-Section <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] 
-	    -From <String> -To <String> [-Dev] [-ScriptInfo] [<CommonParameters>]
-	
-	    C:\Scripts\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] 
-	    [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] 
-	    [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] 
-	    [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
-	    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate 
-	    <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] 
-	    [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] 
-	    [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
-	
-	    C:\Scripts\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] 
-	    [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] 
-	    [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate 
-	    <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] 
-	    [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section 
-	    <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
-	
-	    C:\Scripts\XD7_Inventory_V2.ps1 [-AdminAddress <String>] [-Text] [-Administrators] 
-	    [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-DeliveryGroups] 
-	    [-DeliveryGroupsUtilization] [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate 
-	    <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] 
-	    [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section 
-	    <String>] [-Dev] [-ScriptInfo] [<CommonParameters>]
-	
-	DESCRIPTION
-	    Creates an inventory of a Citrix XenDesktop 7.8+ Site using Microsoft PowerShell, Word,
-	    plain text or HTML.
-	
-	    This Script requires at least PowerShell version 3 but runs best in version 5.
-	
-	    Word is NOT needed to run the script. This script will output in Text and HTML.
-	
-	    You do NOT have to run this script on a Controller. This script was developed and run
-	    from a Windows 10 VM.
-	
-	    You can run this script remotely using the –AdminAddress (AA) parameter.
-	
-	    This script supports versions of XenApp/XenDesktop starting with 7.8.
-	
-	    By default, only gives summary information for:
-	        Administrators
-	        App-V Publishing
-	        AppDisks
-	        AppDNA
-	        Application Groups
-	        Applications
-	        Delivery Groups
-	        Hosting
-	        Logging
-	        Machine Catalogs
-	        Policies
-	        StoreFront
-	        Zones
-	
-	    The Summary information is what is shown in the top half of Citrix Studio for:
-	        Machine Catalogs
-	        AppDisks
-	        Delivery Groups
-	        Applications
-	        Policies
-	        Logging
-	        Administrators
-	        Hosting
-	        StoreFront
-	
-	    Using the MachineCatalogs parameter can cause the report to take a very long time to
-	    complete and can generate an extremely long report.
-	
-	    Using the DeliveryGroups parameter can cause the report to take a very long time to
-	    complete and can generate an extremely long report.
-	
-	    Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-	    take an extremely long time to complete and generate an exceptionally long report.
-	
-	    Creates an output file named after the XenDesktop 7.8+ Site.
-	
-	    Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-	    Includes support for the following language versions of Microsoft Word:
-	        Catalan
-	        Chinese
-	        Danish
-	        Dutch
-	        English
-	        Finnish
-	        French
-	        German
-	        Norwegian
-	        Portuguese
-	        Spanish
-	        Swedish
-	
-	
-	PARAMETERS
-	    -AdminAddress <String>
-	        Specifies the address of a XenDesktop controller the PowerShell snapins will connect
-	        to.
-	        This can be provided as a host name or an IP address.
-	        This parameter defaults to LocalHost.
-	        This parameter has an alias of AA.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                LocalHost
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CompanyAddress <String>
-	        Company Address to use for the Cover Page, if the Cover Page has the Address field.
-	
-	        The following Cover Pages have an Address field:
-	                Banded (Word 2013/2016)
-	                Contrast (Word 2010)
-	                Exposure (Word 2010)
-	                Filigree (Word 2013/2016)
-	                Ion (Dark) (Word 2013/2016)
-	                Retrospect (Word 2013/2016)
-	                Semaphore (Word 2013/2016)
-	                Tiles (Word 2010)
-	                ViewMaster (Word 2013/2016)
-	
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	        This parameter has an alias of CA.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CompanyEmail <String>
-	        Company Email to use for the Cover Page, if the Cover Page has the Email field.
-	
-	        The following Cover Pages have an Email field:
-	                Facet (Word 2013/2016)
-	
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	        This parameter has an alias of CE.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CompanyFax <String>
-	        Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
-	
-	        The following Cover Pages have a Fax field:
-	                Contrast (Word 2010)
-	                Exposure (Word 2010)
-	
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	        This parameter has an alias of CF.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CompanyName <String>
-	        Company Name to use for the Cover Page.
-	        The default value is contained in
-	        HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
-	        HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated
-	        on the computer running the script.
-	        This parameter has an alias of CN.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CompanyPhone <String>
-	        Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
-	
-	        The following Cover Pages have a Phone field:
-	                Contrast (Word 2010)
-	                Exposure (Word 2010)
-	
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	        This parameter has an alias of CPh.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -CoverPage <String>
-	        What Microsoft Word Cover Page to use.
-	        Only Word 2010, 2013 and 2016 are supported.
-	        (default cover pages in Word en-US)
-	
-	        Valid input is:
-	                Alphabet (Word 2010. Works)
-	                Annual (Word 2010. Doesn't work well for this report)
-	                Austere (Word 2010. Works)
-	                Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-	                works in 2010 but Subtitle/Subject & Author fields need to be moved
-	                after title box is moved up)
-	                Banded (Word 2013/2016. Works)
-	                Conservative (Word 2010. Works)
-	                Contrast (Word 2010. Works)
-	                Cubicles (Word 2010. Works)
-	                Exposure (Word 2010. Works if you like looking sideways)
-	                Facet (Word 2013/2016. Works)
-	                Filigree (Word 2013/2016. Works)
-	                Grid (Word 2010/2013/2016. Works in 2010)
-	                Integral (Word 2013/2016. Works)
-	                Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-	                manually resized or font changed to 8 point)
-	                Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-	                manually resized or font changed to 8 point)
-	                Mod (Word 2010. Works)
-	                Motion (Word 2010/2013/2016. Works if top date is manually changed to
-	                36 point)
-	                Newsprint (Word 2010. Works but date is not populated)
-	                Perspective (Word 2010. Works)
-	                Pinstripes (Word 2010. Works)
-	                Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-	                resized or font changed to 14 point)
-	                Retrospect (Word 2013/2016. Works)
-	                Semaphore (Word 2013/2016. Works)
-	                Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
-	                2010)
-	                Slice (Dark) (Word 2013/2016. Doesn't work)
-	                Slice (Light) (Word 2013/2016. Doesn't work)
-	                Stacks (Word 2010. Works)
-	                Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-	                Transcend (Word 2010. Works)
-	                ViewMaster (Word 2013/2016. Works)
-	                Whisp (Word 2013/2016. Works)
-	
-	        The default value is Sideline.
-	        This parameter has an alias of CP.
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                Sideline
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -UserName <String>
-	        User name to use for the Cover Page and Footer.
-	        The default value is contained in $env:username
-	        This parameter has an alias of UN.
-	        This parameter is only valid with the MSWORD and PDF output parameters.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                $env:username
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -HTML [<SwitchParameter>]
-	        Creates an HTML file with an .html extension.
-	        This parameter is disabled by default.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -MSWord [<SwitchParameter>]
-	        SaveAs DOCX file
-	        This parameter is set True if no other output format is selected.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -PDF [<SwitchParameter>]
-	        SaveAs PDF file instead of DOCX file.
-	        This parameter is disabled by default.
-	        The PDF file is roughly 5X to 10X larger than the DOCX file.
-	        This parameter requires Microsoft Word to be installed.
-	        This parameter uses the Word SaveAs PDF capability.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Text [<SwitchParameter>]
-	        Creates a formatted text file with a .txt extension.
-	        This parameter is disabled by default.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Administrators [<SwitchParameter>]
-	        Give detailed information for Administrator Scopes and Roles.
-	        This parameter is disabled by default.
-	        This parameter has an alias of Admins.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -AppDisks [<SwitchParameter>]
-	        Gives detailed information for all AppDisks.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of AD.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Applications [<SwitchParameter>]
-	        Gives detailed information for all applications.
-	        This parameter is disabled by default.
-	        This parameter has an alias of Apps.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -BrokerRegistryKeys [<SwitchParameter>]
-	        Adds information on 315 registry keys to the Controller section.
-	
-	        For Word and PDF output, this adds eights pages, per Controller, to the report.
-	        For Text and HTML, this adds 315 lines, per Controller, to the report.
-	        This parameter has an alias of BRK.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -DeliveryGroups [<SwitchParameter>]
-	        Gives detailed information on all desktops in all Desktop (Delivery) Groups.
-	
-	        Using the DeliveryGroups parameter can cause the report to take a very long
-	        time to complete and can generate an extremely long report.
-	
-	        Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-	        report to take an extremely long time to complete and generate an exceptionally
-	        long report.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of DG.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -DeliveryGroupsUtilization [<SwitchParameter>]
-	        Gives a chart with the delivery group utilization for the last 7 days
-	        depending on the information in the database.
-	
-	        This option is only available when the report is generated in Word and requires
-	        Microsoft Excel to be locally installed.
-	
-	        Using the DeliveryGroupsUtilization parameter causes the report to take a longer
-	        time to complete and generates a longer report.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of DGU.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Hosting [<SwitchParameter>]
-	        Give detailed information for Hosts, Host Connections, and Resources.
-	        This parameter is disabled by default.
-	        This parameter has an alias of Host.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Logging [<SwitchParameter>]
-	        Give the Configuration Logging report with, by default, details for the previous
-	        seven days.
-	        This parameter is disabled by default.
-	        This parameter has an alias of Log.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -StartDate <DateTime>
-	        Start date for the Configuration Logging report.
-	
-	        Format for date only is MM/DD/YYYY.
-	
-	        Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	        The double quotes are needed.
-	
-	        The default is today's date minus seven days.
-	        This parameter has an alias of SD.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                ((Get-Date -displayhint date).AddDays(-7))
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -EndDate <DateTime>
-	        End date for the Configuration Logging report.
-	
-	        Format for date only is MM/DD/YYYY.
-	
-	        Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	        The double quotes are needed.
-	
-	        The default is today's date.
-	        This parameter has an alias of ED.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                (Get-Date -displayhint date)
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -MachineCatalogs [<SwitchParameter>]
-	        Gives detailed information for all machines in all Machine Catalogs.
-	
-	        Using the MachineCatalogs parameter can cause the report to take a very long
-	        time to complete and can generate an extremely long report.
-	
-	        Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-	        report to take an extremely long time to complete and generate an exceptionally
-	        long report.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of MC.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -MaxDetails [<SwitchParameter>]
-	        Adds maximum detail to the report.
-	
-	        This is the same as using the following parameters:
-	                Administrators
-	                AppDisks
-	                Applications
-	                BrokerRegistryKeys
-	                DeliveryGroups
-	                HardWare
-	                Hosting
-	                Logging
-	                MachineCatalogs
-	                Policies
-	                StoreFront
-	
-	        Does not change the value of NoADPolicies.
-	
-	        WARNING: Using this parameter can create an extremely large report and
-	        can take a very long time to run.
-	
-	        This parameter has an alias of MAX.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Policies [<SwitchParameter>]
-	        Give detailed information for both Site and Citrix AD based Policies.
-	
-	        Using the Policies parameter can cause the report to take a very long time
-	        to complete and can generate an extremely long report.
-	
-	        There are three related parameters: Policies, NoPolicies and NoADPolicies.
-	
-	        Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of Pol.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -NoPolicies [<SwitchParameter>]
-	        Excludes all Site and Citrix AD-based policy information from the output document.
-	
-	        Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of NP.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -NoADPolicies [<SwitchParameter>]
-	        Excludes all Citrix AD-based policy information from the output document.
-	        Includes only Site policies created in Studio.
-	
-	        This switch is useful in large AD environments, where there may be thousands
-	        of policies, to keep SYSVOL from being searched.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of NoAD.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -StoreFront [<SwitchParameter>]
-	        Give detailed information for StoreFront.
-	        This parameter is disabled by default.
-	        This parameter has an alias of SF.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -AddDateTime [<SwitchParameter>]
-	        Adds a date time stamp to the end of the file name.
-	        Time stamp is in the format of yyyy-MM-dd_HHmm.
-	        June 1, 2017 at 6PM is 2017-06-01_1800.
-	        Output filename will be ReportName_2017-06-01_1800.docx (or .pdf).
-	        This parameter is disabled by default.
-	        This parameter has an alias of ADT.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Folder <String>
-	        Specifies the optional output folder to save the output report.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Hardware [<SwitchParameter>]
-	        Use WMI to gather hardware information on Computer System, Disks, Processor and
-	        Network Interface Cards
-	
-	        This parameter may require the script be run from an elevated PowerShell session
-	        using an account with permission to retrieve hardware information (i.e. Domain Admin
-	        or Local Administrator).
-	
-	        Selecting this parameter will add to both the time it takes to run the script and
-	        size of the report.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of HW.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Section <String>
-	        Processes a specific section of the report.
-	        Valid options are:
-	                Admins (Administrators)
-	                AppDisks
-	                AppDNA
-	                Apps (Applications and Application Group Details)
-	                AppV
-	                Catalogs (Machine Catalogs)
-	                Config (Configuration)
-	                Controllers
-	                Groups (Delivery Groups)
-	                Hosting
-	                Licensing
-	                Logging
-	                Policies
-	                StoreFront
-	                Zones
-	                All
-	        This parameter defaults to All sections.
-	
-	        Notes:
-	        Using Logging will force the Logging switch to True.
-	        Using Policies will force the Policies switch to True.
-	        If Policies is selected and the NoPolicies switch is used, the script will terminate.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                All
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -SmtpServer <String>
-	        Specifies the optional email server to send the output report.
-	
-	        Required?                    true
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -SmtpPort <Int32>
-	        Specifies the SMTP port.
-	        The default is 25.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                25
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -UseSSL [<SwitchParameter>]
-	        Specifies whether to use SSL for the SmtpServer.
-	        The default is False.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -From <String>
-	        Specifies the username for the From email address.
-	        If SmtpServer is used, this is a required parameter.
-	
-	        Required?                    true
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -To <String>
-	        Specifies the username for the To email address.
-	        If SmtpServer is used, this is a required parameter.
-	
-	        Required?                    true
-	        Position?                    named
-	        Default value
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -Dev [<SwitchParameter>]
-	        Clears errors at the beginning of the script.
-	        Outputs all errors to a text file at the end of the script.
-	
-	        This is used when the script developer requests more troubleshooting data.
-	        Text file is placed in the same folder from where the script is run.
-	
-	        This parameter is disabled by default.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    -ScriptInfo [<SwitchParameter>]
-	        Outputs information about the script to a text file.
-	        Text file is placed in the same folder from where the script is run.
-	
-	        This parameter is disabled by default.
-	        This parameter has an alias of SI.
-	
-	        Required?                    false
-	        Position?                    named
-	        Default value                False
-	        Accept pipeline input?       false
-	        Accept wildcard characters?  false
-	
-	    <CommonParameters>
-	        This cmdlet supports the common parameters: Verbose, Debug,
-	        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-	        OutBuffer, PipelineVariable, and OutVariable. For more information, see
-	        about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
-	
-	INPUTS
-	    None.  You cannot pipe objects to this script.
-	
-	OUTPUTS
-	    No objects are output from this script.
-	    This script creates a Word, PDF, plain text, or HTML document.
-	
-	NOTES
-	        NAME: XD7_Inventory_V2.ps1
-	        VERSION: 2.07
-	        AUTHOR: Carl Webster
-	        LASTEDIT: September 5, 2017
-	
-	    -------------------------- EXAMPLE 1 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1
-	
-	    Will use all default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    The computer running the script for the AdminAddress.
-	
-	    -------------------------- EXAMPLE 2 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -AdminAddress DDC01
-	
-	    Will use all default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    DDC01 for the AdminAddress.
-	
-	    -------------------------- EXAMPLE 3 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -PDF
-	
-	    Will use all default values and save the document as a PDF file.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    The computer running the script for the AdminAddress.
-	
-	    -------------------------- EXAMPLE 4 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -TEXT
-	
-	    Will use all default values and save the document as a formatted text file.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 5 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -HTML
-	
-	    Will use all default values and save the document as an HTML file.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 6 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MachineCatalogs
-	
-	    Creates a report with full details for all machines in all Machine Catalogs.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 7 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroups
-	
-	    Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 8 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
-	
-	    Creates a report with utilization details for all Desktop (Delivery) Groups.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 9 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
-	
-	    Creates a report with full details for all machines in all Machine Catalogs and
-	    all desktops in all Delivery Groups.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 10 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Applications
-	
-	    Creates a report with full details for all applications.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 11 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Policies
-	
-	    Creates a report with full details for Policies.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 12 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -NoPolicies
-	
-	    Creates a report with no Policy information.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 13 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -NoADPolicies
-	
-	    Creates a report with no Citrix AD based Policy information.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 14 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
-	
-	    Creates a report with full details on Site policies created in Studio but
-	    no Citrix AD based Policy information.
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 15 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Administrators
-	
-	    Creates a report with full details on Administrator Scopes and Roles.
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 16 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2017
-	
-	    -EndDate 01/31/2017
-	
-	    Creates a report with Configuration Logging details for the dates 01/01/2017 through
-	    01/31/2017.
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 17 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2017 10:00:00"
-	
-	    -EndDate "06/01/2017 14:00:00"
-	
-	    Creates a report with Configuration Logging details for the time range
-	    06/01/2017 10:00:00AM through 06/01/2017 02:00:00PM.
-	
-	    Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 18 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Hosting
-	
-	    Creates a report with full details for Hosts, Host Connections, and Resources.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 19 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -StoreFront
-	
-	    Creates a report with full details for StoreFront.
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 20 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications
-	
-	    -Policies -Hosting -StoreFront
-	
-	    Creates a report with full details for all:
-	        Machines in all Machine Catalogs
-	        Desktops in all Delivery Groups
-	        Applications
-	        Policies
-	        Hosts, Host Connections, and Resources
-	        StoreFront
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 21 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
-	
-	    Creates a report with full details for all:
-	        Machines in all Machine Catalogs
-	        Desktops in all Delivery Groups
-	        Applications
-	        Policies
-	        Hosts, Host Connections, and Resources
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 22 --------------------------
-	
-	    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting" 
-	    -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
-	
-	    Will use:
-	        Carl Webster Consulting for the Company Name.
-	        Mod for the Cover Page format.
-	        Carl Webster for the User Name.
-	        Controller named DDC01 for the AdminAddress.
-	
-	    -------------------------- EXAMPLE 23 --------------------------
-	
-	    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod" 
-	    -UN "Carl Webster"
-	
-	    Will use:
-	        Carl Webster Consulting for the Company Name (alias CN).
-	        Mod for the Cover Page format (alias CP).
-	        Carl Webster for the User Name (alias UN).
-	        The computer running the script for the AdminAddress.
-	
-	    -------------------------- EXAMPLE 24 --------------------------
-	
-	    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" 
-	    -CoverPage Exposure -UserName "Dr. Watson"
-	    -CompanyAddress "221B Baker Street, London, England"
-	    -CompanyFax "+44 1753 276600"
-	    -CompanyPhone "+44 1753 276200"
-	
-	    Will use:
-	        Sherlock Holmes Consulting for the Company Name.
-	        Exposure for the Cover Page format.
-	        Dr. Watson for the User Name.
-	        221B Baker Street, London, England for the Company Address.
-	        +44 1753 276600 for the Company Fax.
-	        +44 1753 276200 for the Compnay Phone.
-	
-	    -------------------------- EXAMPLE 25 --------------------------
-	
-	    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" 
-	    -CoverPage Facet -UserName "Dr. Watson"
-	    -CompanyEmail SuperSleuth@SherlockHolmes.com
-	
-	    Will use:
-	        Sherlock Holmes Consulting for the Company Name.
-	        Facet for the Cover Page format.
-	        Dr. Watson for the User Name.
-	        SuperSleuth@SherlockHolmes.com for the Compnay Email.
-	
-	    -------------------------- EXAMPLE 26 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -AddDateTime
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    Adds a date time stamp to the end of the file name.
-	    Time stamp is in the format of yyyy-MM-dd_HHmm.
-	    June 1, 2017 at 6PM is 2017-06-01_1800.
-	    Output filename will be XD7SiteName_2017-06-01_1800.docx
-	
-	    -------------------------- EXAMPLE 27 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -PDF -AddDateTime
-	
-	    Will use all Default values and save the document as a PDF file.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    Adds a date time stamp to the end of the file name.
-	    Time stamp is in the format of yyyy-MM-dd_HHmm.
-	    June 1, 2017 at 6PM is 2017-06-01_1800.
-	    Output filename will be XD7SiteName_2017-06-01_1800.pdf
-	
-	    -------------------------- EXAMPLE 28 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Hardware
-	
-	    Will use all default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    -------------------------- EXAMPLE 29 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Folder \\FileServer\ShareName
-	
-	    Will use all default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    Output file will be saved in the path \\FileServer\ShareName
-	
-	    -------------------------- EXAMPLE 30 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld 
-	    -From XDAdmin@domain.tld -To ITGroup@domain.tld
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-	    sending to ITGroup@domain.tld.
-	
-	    Script will use the default SMTP port 25 and will not use SSL.
-	
-	    If the current user's credentials are not valid to send email,
-	    the user will be prompted to enter valid credentials.
-	
-	    -------------------------- EXAMPLE 31 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 
-	    -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    The script will use the email server smtp.office365.com on port 587 using SSL,
-	    sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-	
-	    If the current user's credentials are not valid to send email,
-	    the user will be prompted to enter valid credentials.
-	
-	    -------------------------- EXAMPLE 32 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Policies
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    Processes only the Policies section of the report.
-	
-	    -------------------------- EXAMPLE 33 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Groups -DG
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    Processes only the Delivery Groups section of the report with Delivery Group details.
-	
-	    -------------------------- EXAMPLE 34 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Groups
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    Processes only the Delivery Groups section of the report with no Delivery Group details.
-	
-	    -------------------------- EXAMPLE 35 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	    Adds the information on 315 Broker registry keys to the Controllers section.
-	
-	    -------------------------- EXAMPLE 36 --------------------------
-	
-	    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MaxDetails
-	
-	    Will use all Default values.
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
-	    Webster" or
-	    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	    $env:username = Administrator
-	
-	    Carl Webster for the Company Name.
-	    Sideline for the Cover Page format.
-	    Administrator for the User Name.
-	
-	    Set the following parameter values:
-	        Administrators      = True
-	        AppDisks            = True
-	        Applications        = True
-	        BrokerRegistryKeys  = True
-	        DeliveryGroups      = True
-	        HardWare            = True
-	        Hosting             = True
-	        Logging             = True
-	        MachineCatalogs     = True
-	        Policies            = True
-	        StoreFront          = True
-	
-	        NoPolicies          = False
-	        Section             = "All"
+PS C:\Scripts> get-help .\XD7_Inventory_V2.ps1 -full
+
+NAME
+    C:\Scripts\XD7_Inventory_V2.ps1
+
+SYNOPSIS
+    Creates an inventory of a Citrix XenDesktop 7.8+ Site.
+
+SYNTAX
+    C:\Scripts\XD7_Inventory_V2.ps1 [-MSWord] [-AddDateTime] [-AdminAddress 
+    <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
+    [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] 
+    [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] 
+    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder 
+    <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] 
+    [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] 
+    [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] [-VDARegistryKeys] 
+    [<CommonParameters>]
+
+    C:\Scripts\XD7_Inventory_V2.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] 
+    [-AdminAddress <String>] [-Administrators] [-AppDisks] [-Applications] 
+    [-BrokerRegistryKeys] [-CompanyAddress <String>] [-CompanyEmail <String>] 
+    [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage 
+    <String>] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] 
+    [-Folder <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] 
+    [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section 
+    <String>] [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] 
+    [-VDARegistryKeys] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL]
+    -From <String> -To <String> [<CommonParameters>]
+
+    C:\Scripts\XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress 
+    <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
+    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder 
+    <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] 
+    [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] 
+    [-StartDate <DateTime>] [-StoreFront] [-VDARegistryKeys] [<CommonParameters>]
+
+    C:\Scripts\XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] 
+    [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-CompanyAddress 
+    <String>] [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] 
+    [-CompanyPhone <String>] [-CoverPage <String>] [-DeliveryGroups] 
+    [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder <String>] 
+    [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] 
+    [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] 
+    [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] [-VDARegistryKeys] 
+    [<CommonParameters>]
+
+    C:\Scripts\XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress 
+    <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] 
+    [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder 
+    <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] 
+    [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] 
+    [-StartDate <DateTime>] [-StoreFront] [-VDARegistryKeys] [<CommonParameters>]
+
+
+DESCRIPTION
+    Creates an inventory of a Citrix XenDesktop 7.8+ Site using Microsoft PowerShell, Word,
+    plain text, or HTML.
+
+    This Script requires at least PowerShell version 3 but runs best in version 5.
+
+    Word is NOT needed to run the script. This script will output in Text and HTML.
+
+    You do NOT have to run this script on a Controller. This script was developed and run
+    from a Windows 10 VM.
+
+    You can run this script remotely using the –AdminAddress (AA) parameter.
+
+    This script supports versions of XenApp/XenDesktop starting with 7.8.
+
+    By default, only gives summary information for:
+        Administrators
+        App-V Publishing
+        AppDisks
+        AppDNA
+        Application Groups
+        Applications
+        Delivery Groups
+        Hosting
+        Logging
+        Machine Catalogs
+        Policies
+        StoreFront
+        Zones
+
+    The Summary information is what is shown in the top half of Citrix Studio for:
+        Machine Catalogs
+        AppDisks
+        Delivery Groups
+        Applications
+        Policies
+        Logging
+        Administrators
+        Hosting
+        StoreFront
+
+    Using the MachineCatalogs parameter can cause the report to take a very long time to
+    complete and can generate an extremely long report.
+
+    Using the DeliveryGroups parameter can cause the report to take a very long time to
+    complete and can generate an extremely long report.
+
+    Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
+    take an extremely long time to complete and generate an exceptionally long report.
+
+    Creates an output file named after the XenDesktop 7.8+ Site.
+
+    Word and PDF Document includes a Cover Page, Table of Contents and Footer.
+    Includes support for the following language versions of Microsoft Word:
+        Catalan
+        Chinese
+        Danish
+        Dutch
+        English
+        Finnish
+        French
+        German
+        Norwegian
+        Portuguese
+        Spanish
+        Swedish
+
+
+
+PARAMETERS
+    -HTML [<SwitchParameter>]
+        Creates an HTML file with an .html extension.
+        This parameter is disabled by default.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -MSWord [<SwitchParameter>]
+        SaveAs DOCX file
+        This parameter is set True if no other output format is selected.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -PDF [<SwitchParameter>]
+        SaveAs PDF file instead of DOCX file.
+        This parameter is disabled by default.
+        The PDF file is roughly 5X to 10X larger than the DOCX file.
+        This parameter requires Microsoft Word to be installed.
+        This parameter uses the Word SaveAs PDF capability.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Text [<SwitchParameter>]
+        Creates a formatted text file with a .txt extension.
+        This parameter is disabled by default.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -AddDateTime [<SwitchParameter>]
+        Adds a date timestamp to the end of the file name.
+        The timestamp is in the format of yyyy-MM-dd_HHmm.
+        June 1, 2019 at 6PM is 2019-06-01_1800.
+        Output filename will be ReportName_2019-06-01_1800.docx (or .pdf).
+        This parameter is disabled by default.
+        This parameter has an alias of ADT.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -AdminAddress <String>
+        Specifies the address of a XenDesktop controller the PowerShell snapins will connect
+        to.
+        This can be provided as a hostname or an IP address.
+        This parameter defaults to Localhost.
+        This parameter has an alias of AA.
+
+        Required?                    false
+        Position?                    named
+        Default value                Localhost
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Administrators [<SwitchParameter>]
+        Give detailed information for Administrator Scopes and Roles.
+        This parameter is disabled by default.
+        This parameter has an alias of Admins.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -AppDisks [<SwitchParameter>]
+        Gives detailed information for all AppDisks.
+
+        This parameter is disabled by default.
+        This parameter has an alias of AD.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Applications [<SwitchParameter>]
+        Gives detailed information for all applications.
+        This parameter is disabled by default.
+        This parameter has an alias of Apps.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -BrokerRegistryKeys [<SwitchParameter>]
+        Adds information on 315 registry keys to the Controller section.
+
+        For Word and PDF output, this adds eights pages, per Controller, to the report.
+        For Text and HTML, this adds 315 lines, per Controller, to the report.
+
+        This parameter is disabled by default.
+        This parameter has an alias of BRK.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CompanyAddress <String>
+        Company Address to use for the Cover Page, if the Cover Page has the Address field.
+
+        The following Cover Pages have an Address field:
+                Banded (Word 2013/2016)
+                Contrast (Word 2010)
+                Exposure (Word 2010)
+                Filigree (Word 2013/2016)
+                Ion (Dark) (Word 2013/2016)
+                Retrospect (Word 2013/2016)
+                Semaphore (Word 2013/2016)
+                Tiles (Word 2010)
+                ViewMaster (Word 2013/2016)
+
+        This parameter is only valid with the MSWORD and PDF output parameters.
+        This parameter has an alias of CA.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CompanyEmail <String>
+        Company Email to use for the Cover Page, if the Cover Page has the Email field.
+
+        The following Cover Pages have an Email field:
+                Facet (Word 2013/2016)
+
+        This parameter is only valid with the MSWORD and PDF output parameters.
+        This parameter has an alias of CE.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CompanyFax <String>
+        Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+
+        The following Cover Pages have a Fax field:
+                Contrast (Word 2010)
+                Exposure (Word 2010)
+
+        This parameter is only valid with the MSWORD and PDF output parameters.
+        This parameter has an alias of CF.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CompanyName <String>
+        Company Name to use for the Cover Page.
+        The default value is contained in
+        HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
+        HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated
+        on the computer running the script.
+
+        This parameter is only valid with the MSWORD and PDF output parameters.
+        This parameter has an alias of CN.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CompanyPhone <String>
+        Company Phone to use for the Cover Page if the Cover Page has the Phone field.
+
+        The following Cover Pages have a Phone field:
+                Contrast (Word 2010)
+                Exposure (Word 2010)
+
+        This parameter is only valid with the MSWORD and PDF output parameters.
+        This parameter has an alias of CPh.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -CoverPage <String>
+        What Microsoft Word Cover Page to use.
+        Only Word 2010, 2013 and 2016 are supported.
+        (default cover pages in Word en-US)
+
+        Valid input is:
+                Alphabet (Word 2010. Works)
+                Annual (Word 2010. Doesn't work well for this report)
+                Austere (Word 2010. Works)
+                Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+                works in 2010 but Subtitle/Subject & Author fields need to be moved
+                after title box is moved up)
+                Banded (Word 2013/2016. Works)
+                Conservative (Word 2010. Works)
+                Contrast (Word 2010. Works)
+                Cubicles (Word 2010. Works)
+                Exposure (Word 2010. Works if you like looking sideways)
+                Facet (Word 2013/2016. Works)
+                Filigree (Word 2013/2016. Works)
+                Grid (Word 2010/2013/2016. Works in 2010)
+                Integral (Word 2013/2016. Works)
+                Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+                manually resized or font changed to 8 point)
+                Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+                manually resized or font changed to 8 point)
+                Mod (Word 2010. Works)
+                Motion (Word 2010/2013/2016. Works if top date is manually changed to
+                36 point)
+                Newsprint (Word 2010. Works but date is not populated)
+                Perspective (Word 2010. Works)
+                Pinstripes (Word 2010. Works)
+                Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+                resized or font changed to 14 point)
+                Retrospect (Word 2013/2016. Works)
+                Semaphore (Word 2013/2016. Works)
+                Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+                2010)
+                Slice (Dark) (Word 2013/2016. Doesn't work)
+                Slice (Light) (Word 2013/2016. Doesn't work)
+                Stacks (Word 2010. Works)
+                Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+                Transcend (Word 2010. Works)
+                ViewMaster (Word 2013/2016. Works)
+                Whisp (Word 2013/2016. Works)
+
+        The default value is Sideline.
+        This parameter has an alias of CP.
+        This parameter is only valid with the MSWORD and PDF output parameters.
+
+        Required?                    false
+        Position?                    named
+        Default value                Sideline
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -DeliveryGroups [<SwitchParameter>]
+        Gives detailed information on all desktops in all Desktop (Delivery) Groups.
+
+        Using the DeliveryGroups parameter can cause the report to take a very long
+        time to complete and can generate an extremely long report.
+
+        Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+        report to take an extremely long time to complete and generate an exceptionally
+        long report.
+
+        This parameter is disabled by default.
+        This parameter has an alias of DG.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -DeliveryGroupsUtilization [<SwitchParameter>]
+        Gives a chart with the delivery group utilization for the last 7 days
+        depending on the information in the database.
+
+        This option is only available when the report is generated in Word and requires
+        Microsoft Excel to be locally installed.
+
+        Using the DeliveryGroupsUtilization parameter causes the report to take a longer
+        time to complete and generates a longer report.
+
+        This parameter is disabled by default.
+        This parameter has an alias of DGU.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Dev [<SwitchParameter>]
+        Clears errors at the beginning of the script.
+        Outputs all errors to a text file at the end of the script.
+
+        This is used when the script developer requests more troubleshooting data.
+        The text file is placed in the same folder from where the script is run.
+
+        This parameter is disabled by default.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -EndDate <DateTime>
+        The end date for the Configuration Logging report.
+
+        The format for date only is MM/DD/YYYY.
+
+        Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+        The double quotes are needed.
+
+        The default is today's date.
+        This parameter has an alias of ED.
+
+        Required?                    false
+        Position?                    named
+        Default value                (Get-Date -displayhint date)
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Folder <String>
+        Specifies the optional output folder to save the output report.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Hardware [<SwitchParameter>]
+        Use WMI to gather hardware information on Computer System, Disks, Processor, and
+        Network Interface Cards
+
+        This parameter may require the script be run from an elevated PowerShell session
+        using an account with permission to retrieve hardware information (i.e. Domain Admin
+        or Local Administrator).
+
+        Selecting this parameter will add to both the time it takes to run the script and
+        size of the report.
+
+        This parameter is disabled by default.
+        This parameter has an alias of HW.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Hosting [<SwitchParameter>]
+        Give detailed information for Hosts, Host Connections, and Resources.
+        This parameter is disabled by default.
+        This parameter has an alias of Host.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Log [<SwitchParameter>]
+        Generates a log file for troubleshooting.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Logging [<SwitchParameter>]
+        Give the Configuration Logging report with, by default, details for the previous
+        seven days.
+        This parameter is disabled by default.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -MachineCatalogs [<SwitchParameter>]
+        Gives detailed information for all machines in all Machine Catalogs.
+
+        Using the MachineCatalogs parameter can cause the report to take a very long
+        time to complete and can generate an extremely long report.
+
+        Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+        report to take an extremely long time to complete and generate an exceptionally
+        long report.
+
+        This parameter is disabled by default.
+        This parameter has an alias of MC.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -MaxDetails [<SwitchParameter>]
+        Adds maximum detail to the report.
+
+        This is the same as using the following parameters:
+                Administrators
+                AppDisks
+                Applications
+                BrokerRegistryKeys
+                VDARegistryKeys
+                DeliveryGroups
+                HardWare
+                Hosting
+                Logging
+                MachineCatalogs
+                Policies
+                StoreFront
+
+        Does not change the value of NoADPolicies.
+
+        WARNING: Using this parameter can create an extremely large report and
+        can take a very long time to run.
+
+        This parameter has an alias of MAX.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -NoADPolicies [<SwitchParameter>]
+        Excludes all Citrix AD-based policy information from the output document.
+        Includes only Site policies created in Studio.
+
+        This switch is useful in large AD environments, where there may be thousands
+        of policies, to keep SYSVOL from being searched.
+
+        This parameter is disabled by default.
+        This parameter has an alias of NoAD.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -NoPolicies [<SwitchParameter>]
+        Excludes all Site and Citrix AD-based policy information from the output document.
+
+        Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+
+        This parameter is disabled by default.
+        This parameter has an alias of NP.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Policies [<SwitchParameter>]
+        Give detailed information for both Site and Citrix AD based Policies.
+
+        Using the Policies parameter can cause the report to take a very long time
+        to complete and can generate an extremely long report.
+
+        Note: The Citrix Group Policy PowerShell module will not load from an elevated 
+        PowerShell session.
+        If the module is manually imported, the module is not detected from an elevated 
+        PowerShell session.
+
+        There are three related parameters: Policies, NoPolicies, and NoADPolicies.
+
+        Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
+
+        This parameter is disabled by default.
+        This parameter has an alias of Pol.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -ScriptInfo [<SwitchParameter>]
+        Outputs information about the script to a text file.
+        The text file is placed in the same folder from where the script is run.
+
+        This parameter is disabled by default.
+        This parameter has an alias of SI.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Section <String>
+        Processes a specific section of the report.
+        Valid options are:
+                Admins (Administrators)
+                AppDisks
+                AppDNA
+                Apps (Applications and Application Group Details)
+                AppV
+                Catalogs (Machine Catalogs)
+                Config (Configuration)
+                Controllers
+                Groups (Delivery Groups)
+                Hosting
+                Licensing
+                Logging
+                Policies
+                StoreFront
+                Zones
+                All
+        This parameter defaults to All sections.
+
+        Notes:
+        Using Logging will force the Logging switch to True.
+        Using Policies will force the Policies switch to True.
+        If Policies is selected and the NoPolicies switch is used, the script will terminate.
+
+        Required?                    false
+        Position?                    named
+        Default value                All
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -StartDate <DateTime>
+        The start date for the Configuration Logging report.
+
+        The format for date only is MM/DD/YYYY.
+
+        Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+        The double quotes are needed.
+
+        The default is today's date minus seven days.
+        This parameter has an alias of SD.
+
+        Required?                    false
+        Position?                    named
+        Default value                ((Get-Date -displayhint date).AddDays(-7))
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -StoreFront [<SwitchParameter>]
+        Give detailed information for StoreFront.
+        This parameter is disabled by default.
+        This parameter has an alias of SF.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -UserName <String>
+        Username to use for the Cover Page and Footer.
+        The default value is contained in $env:username
+        This parameter has an alias of UN.
+        This parameter is only valid with the MSWORD and PDF output parameters.
+
+        Required?                    false
+        Position?                    named
+        Default value                $env:username
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -VDARegistryKeys [<SwitchParameter>]
+        Adds information on registry keys to the Machine Details section.
+
+        If this parameter is used, MachineCatalogs is set to True.
+
+        This parameter is disabled by default.
+        This parameter has an alias of VRK.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -SmtpServer <String>
+        Specifies the optional email server to send the output report.
+
+        Required?                    true
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -SmtpPort <Int32>
+        Specifies the SMTP port.
+        The default is 25.
+
+        Required?                    false
+        Position?                    named
+        Default value                25
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -UseSSL [<SwitchParameter>]
+        Specifies whether to use SSL for the SmtpServer.
+        The default is False.
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -From <String>
+        Specifies the username for the From email address.
+        If SmtpServer is used, this is a required parameter.
+
+        Required?                    true
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -To <String>
+        Specifies the username for the To email address.
+        If SmtpServer is used, this is a required parameter.
+
+        Required?                    true
+        Position?                    named
+        Default value
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+
+INPUTS
+    None.  You cannot pipe objects to this script.
+
+
+OUTPUTS
+    No objects are output from this script.
+    This script creates a Word, PDF, plain text, or HTML document.
+
+NOTES
+        NAME: XD7_Inventory_V2.ps1
+        VERSION: 2.21
+        AUTHOR: Carl Webster
+        LASTEDIT: January 26, 2019
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1
+
+    Will use all default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    The computer running the script for the AdminAddress.
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -AdminAddress DDC01
+
+    Will use all default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    DDC01 for the AdminAddress.
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -PDF
+
+    Will use all default values and save the document as a PDF file.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    The computer running the script for the AdminAddress.
+
+
+
+    -------------------------- EXAMPLE 4 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -TEXT
+
+    Will use all default values and save the document as a formatted text file.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+    -------------------------- EXAMPLE 5 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -HTML
+
+    Will use all default values and save the document as an HTML file.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+    -------------------------- EXAMPLE 6 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MachineCatalogs
+
+    Creates a report with full details for all machines in all Machine Catalogs.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    -------------------------- EXAMPLE 7 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroups
+
+    Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 8 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
+
+    Creates a report with utilization details for all Desktop (Delivery) Groups.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 9 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
+
+    Creates a report with full details for all machines in all Machine Catalogs and
+    all desktops in all Delivery Groups.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 10 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Applications
+
+    Creates a report with full details for all applications.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    -------------------------- EXAMPLE 11 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Policies
+
+    Creates a report with full details for Policies.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 12 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -NoPolicies
+
+    Creates a report with no Policy information.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 13 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -NoADPolicies
+
+    Creates a report with no Citrix AD based Policy information.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    -------------------------- EXAMPLE 14 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
+
+    Creates a report with full details on Site policies created in Studio but
+    no Citrix AD based Policy information.
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    -------------------------- EXAMPLE 15 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Administrators
+
+    Creates a report with full details on Administrator Scopes and Roles.
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 16 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2019
+    -EndDate 01/31/2019
+
+    Creates a report with Configuration Logging details for the dates 01/01/2019 through
+    01/31/2019.
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 17 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2019 10:00:00"
+    -EndDate "06/01/2019 14:00:00"
+
+    Creates a report with Configuration Logging details for the time range
+    06/01/2019 10:00:00AM through 06/01/2019 02:00:00PM.
+
+    Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 18 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Hosting
+
+    Creates a report with full details for Hosts, Host Connections, and Resources.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 19 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -StoreFront
+
+    Creates a report with full details for StoreFront.
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 20 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups
+    -Applications -Policies -Hosting -StoreFront
+
+    Creates a report with full details for all:
+        Machines in all Machine Catalogs
+        Desktops in all Delivery Groups
+        Applications
+        Policies
+        Hosts, Host Connections, and Resources
+        StoreFront
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+
+    -------------------------- EXAMPLE 21 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
+
+    Creates a report with full details for all:
+        Machines in all Machine Catalogs
+        Desktops in all Delivery Groups
+        Applications
+        Policies
+        Hosts, Host Connections, and Resources
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+    -------------------------- EXAMPLE 22 --------------------------
+
+    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+    -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+
+    Will use:
+        Carl Webster Consulting for the Company Name.
+        Mod for the Cover Page format.
+        Carl Webster for the User Name.
+        Controller named DDC01 for the AdminAddress.
+
+
+    -------------------------- EXAMPLE 23 --------------------------
+
+    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+    -UN "Carl Webster"
+
+    Will use:
+        Carl Webster Consulting for the Company Name (alias CN).
+        Mod for the Cover Page format (alias CP).
+        Carl Webster for the User Name (alias UN).
+        The computer running the script for the AdminAddress.
+
+
+    -------------------------- EXAMPLE 24 --------------------------
+
+    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+    -CoverPage Exposure -UserName "Dr. Watson"
+    -CompanyAddress "221B Baker Street, London, England"
+    -CompanyFax "+44 1753 276600"
+    -CompanyPhone "+44 1753 276200"
+
+    Will use:
+        Sherlock Holmes Consulting for the Company Name.
+        Exposure for the Cover Page format.
+        Dr. Watson for the User Name.
+        221B Baker Street, London, England for the Company Address.
+        +44 1753 276600 for the Company Fax.
+        +44 1753 276200 for the Company Phone.
+
+
+    -------------------------- EXAMPLE 25 --------------------------
+
+    PS C:\>PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+    -CoverPage Facet -UserName "Dr. Watson"
+    -CompanyEmail SuperSleuth@SherlockHolmes.com
+
+    Will use:
+        Sherlock Holmes Consulting for the Company Name.
+        Facet for the Cover Page format.
+        Dr. Watson for the User Name.
+        SuperSleuth@SherlockHolmes.com for the Company Email.
+
+
+
+
+    -------------------------- EXAMPLE 26 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -AddDateTime
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    Adds a date time stamp to the end of the file name.
+    The timestamp is in the format of yyyy-MM-dd_HHmm.
+    June 1, 2019 at 6PM is 2019-06-01_1800.
+    Output filename will be XD7SiteName_2019-06-01_1800.docx
+
+
+
+
+    -------------------------- EXAMPLE 27 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -PDF -AddDateTime
+
+    Will use all Default values and save the document as a PDF file.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    Adds a date time stamp to the end of the file name.
+    The timestamp is in the format of yyyy-MM-dd_HHmm.
+    June 1, 2019 at 6PM is 2019-06-01_1800.
+    Output filename will be XD7SiteName_2019-06-01_1800.pdf
+
+
+
+
+ 
+
+
+
+   -------------------------- EXAMPLE 28 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Hardware
+
+    Will use all default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+
+
+
+    -------------------------- EXAMPLE 29 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Folder \\FileServer\ShareName
+
+    Will use all default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    Output file will be saved in the path \\FileServer\ShareName
+
+
+
+
+    -------------------------- EXAMPLE 30 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld
+    -From XDAdmin@domain.tld -To ITGroup@domain.tld
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+    sending to ITGroup@domain.tld.
+
+    The script will use the default SMTP port 25 and will not use SSL.
+
+    If the current user's credentials are not valid to send email,
+    the user will be prompted to enter valid credentials.
+
+
+
+
+  
+    -------------------------- EXAMPLE 31 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+    -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    The script will use the email server smtp.office365.com on port 587 using SSL,
+    sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+
+    If the current user's credentials are not valid to send email,
+    the user will be prompted to enter valid credentials.
+
+
+
+
+    -------------------------- EXAMPLE 32 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Policies
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    Processes only the Policies section of the report.
+
+
+
+
+    -------------------------- EXAMPLE 33 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Groups -DG
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    Processes only the Delivery Groups section of the report with Delivery Group details.
+
+
+
+
+   
+
+
+    -------------------------- EXAMPLE 34 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Section Groups
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    Processes only the Delivery Groups section of the report with no Delivery Group details.
+
+
+
+
+    -------------------------- EXAMPLE 35 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    Adds the information on over 300 Broker registry keys to the Controllers section.
+
+
+
+
+    -------------------------- EXAMPLE 36 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -VDARegistryKeys
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+    Adds the information on VDA registry keys to the Machine Details section.
+    Forces the MachineCatalogs parameter to $True
+
+
+
+
+    -------------------------- EXAMPLE 37 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -MaxDetails
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    Set the following parameter values:
+        Administrators      = True
+        AppDisks            = True
+        Applications        = True
+        BrokerRegistryKeys  = True
+        VDARegistryKeys         = True
+        DeliveryGroups      = True
+        HardWare            = True
+        Hosting             = True
+        Logging             = True
+        MachineCatalogs     = True
+        Policies            = True
+        StoreFront          = True
+
+        NoPolicies          = False
+        Section             = "All"
+
+
+
+
+    -------------------------- EXAMPLE 38 --------------------------
+
+    PS C:\PSScript >.\XD7_Inventory_V2.ps1 -Dev -ScriptInfo -Log
+
+    Will use all Default values.
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl
+    Webster" or
+    HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+    $env:username = Administrator
+
+    Carl Webster for the Company Name.
+    Sideline for the Cover Page format.
+    Administrator for the User Name.
+
+    Creates a text file named XAXDV2InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+    contains up to the last 250 errors reported by the script.
+
+    Creates a text file named XAXDV2InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+    contains all the script parameters and other basic information.
+
+    Creates a text file for transcript logging named
+    XDV2DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
 	
 	RELATED LINKS
 	

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -990,7 +990,7 @@
 	NAME: XD7_Inventory_V2.ps1
 	VERSION: 2.21
 	AUTHOR: Carl Webster
-	LASTEDIT: January 26, 2019
+	LASTEDIT: February 1, 2019
 #>
 
 #endregion
@@ -1188,7 +1188,10 @@ Param(
 
 # This script is based on the 1.20 script
 
-#Version 2.21
+#Version 2.21 1-Feb-2019
+#	Added additional VDA registry key data to Machine details for Local Text Echo added back in VDA 1811
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\UseDirect3D
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\PresentDevice
 #	Added License Server version
 #	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
 #	Added test to catch multiple output parameters used
@@ -8004,6 +8007,10 @@ Function GetVDARegistryKeys
 
 	If($xType -eq "Server")
 	{
+		#added in V2.21 for Local Text Echo added back in VDA 1811
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "UseDirect3D" $ComputerName $xType
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "PresentDevice" $ComputerName $xType
+		
 		#From the 1811 docs
 		Get-VDARegKeyToObject "HKLM:\System\Currentcontrolset\services\picadm\Parameters" "DisableFullStreamWrite" $ComputerName $xType
 		Get-VDARegKeyToObject "HKLM:\SYSTEM\CurrentControlSet\Control\SCMConfig" "EnableSvchostMitigationPolicy" $ComputerName $xType
@@ -8062,6 +8069,10 @@ Function GetVDARegistryKeys
 	}
 	ElseIf($xType -eq "Desktop")
 	{
+		#added in V2.21 for Local Text Echo added back in VDA 1811
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "UseDirect3D" $ComputerName $xType
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "PresentDevice" $ComputerName $xType
+		
 		#From What's New and Fixed in 7.18
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Citrix\Citrix Virtual Desktop Agent" "DisableLogonUISuppression" $ComputerName $xType
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Citrix\SmartCard" "EnableSCardHookVcResponseTimeout" $ComputerName $xType
@@ -32247,7 +32258,6 @@ Function OutputDesktopOSMachine
 {
 	Param([object]$Desktop)
 
-	$xName = ""
 	$xMaintMode = ""
 	$xUserChanges = ""
 	
@@ -32416,7 +32426,6 @@ Function OutputServerOSMachine
 	Param([object]$Server)
 	
 	Write-Verbose "$(Get-Date): `t`t`tOutput server $($Server.DNSName)"
-	$xName = ""
 	$xMaintMode = ""
 	$xUserChanges = ""
 

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -1191,6 +1191,7 @@ Param(
 #Version 2.21
 #	Added License Server version
 #	Added the restart schedule "Frequency notification" to Delivery Group details
+#	For Application details, changed "Description" to "Description and keywords"
 
 #Version 2.20.2 26-Dec-2018
 #	Fixed Function OutputAppendixA to fix duplicate VDA registry lines
@@ -13213,7 +13214,7 @@ Function OutputApplicationDetails
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{Data = "Name (for administrator)"; Value = $Application.Name; }
 		$ScriptInformation += @{Data = "Name (for user)"; Value = $Application.PublishedName; }
-		$ScriptInformation += @{Data = "Description"; Value = $Application.Description; }
+		$ScriptInformation += @{Data = "Description and keywords"; Value = $Application.Description; }
 		$ScriptInformation += @{Data = "Delivery Group"; Value = $DeliveryGroups[0]; }
 		$cnt = -1
 		ForEach($Group in $DeliveryGroups)
@@ -13358,7 +13359,7 @@ Function OutputApplicationDetails
 	{
 		Line 1 "Name (for administrator)`t`t: " $Application.Name
 		Line 1 "Name (for user)`t`t`t`t: " $Application.PublishedName
-		Line 1 "Description`t`t`t`t: " $Application.Description
+		Line 1 "Description and keywords`t`t: " $Application.Description
 		Line 1 "Delivery Group`t`t`t`t: " $DeliveryGroups[0]
 		$cnt = -1
 		ForEach($Group in $DeliveryGroups)
@@ -13481,7 +13482,7 @@ Function OutputApplicationDetails
 		$rowdata = @()
 		$columnHeaders = @("Name (for administrator)",($htmlsilver -bor $htmlbold),$Application.Name,$htmlwhite)
 		$rowdata += @(,('Name (for user)',($htmlsilver -bor $htmlbold),$Application.PublishedName,$htmlwhite))
-		$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Application.Description,$htmlwhite))
+		$rowdata += @(,('Description and keywords',($htmlsilver -bor $htmlbold),$Application.Description,$htmlwhite))
 		$rowdata += @(,('Delivery Group',($htmlsilver -bor $htmlbold),$DeliveryGroups[0],$htmlwhite))
 		$cnt = -1
 		ForEach($Group in $DeliveryGroups)

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -1190,11 +1190,12 @@ Param(
 
 #Version 2.21
 #	Added License Server version
-#	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage
+#	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
 #	Added the restart schedule "Frequency notification" to Delivery Group details
 #	Fixed, in Functions OutputDesktopOSMachine and OutputServerOSMachine, the output of users
 #	Fixed bug in Function ProcessHosting where the comparison for $Hypervisor.Name was done incorrectly
-#	For Application details, changed "Description" to "Description and keywords"
+#	For Application details changed "Description" to "Description and keywords"
+#	In the Delivery Controllers section added a blank line after the Word and HTML tables
 
 #Version 2.20.2 26-Dec-2018
 #	Fixed Function OutputAppendixA to fix duplicate VDA registry lines
@@ -30749,6 +30750,7 @@ Function OutputControllers
 
 			FindWordDocumentEnd
 			$Table = $Null
+			WriteWordLine 0 0 "" #added V2.21
 		}
 		ElseIf($Text)
 		{
@@ -30767,6 +30769,7 @@ Function OutputControllers
 			$msg = ""
 			$columnWidths = @("100px","250px")
 			FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
+			WriteHTMLLine 0 0 "" #added V2.21
 		}
 		
 		If($BrokerRegistryKeys)

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -78,10 +78,10 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid205773\rsid219208\rsid265763\rsid346080\rsid595465\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2579094
 \rsid2584542\rsid2902416\rsid2978753\rsid3300860\rsid3430394\rsid3542051\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229
 \rsid7733837\rsid7763859\rsid8350100\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12258164\rsid12271374
-\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14697282\rsid14828264\rsid14881286\rsid15613047\rsid15623927\rsid15678052\rsid15692337
-\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
-{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo12\dy26\hr10\min25}{\version60}{\edmins11795}{\nofpages28}{\nofwords8859}{\nofchars50501}{\nofcharsws59242}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/wo
-rd/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14697282\rsid14828264\rsid14881286\rsid15613047\rsid15623927\rsid15678052
+\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0
+\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo1\dy26\hr7\min27}{\version61}{\edmins11795}{\nofpages28}{\nofwords8859}{\nofchars50498}{\nofcharsws59239}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas.microsof
+t.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYYGtQASRr7lLQAAAA==}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
@@ -190,7 +190,7 @@ Orchestration_PowerShellSnapIn_x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -230,7 +230,7 @@ WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e000000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
 . The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 
@@ -367,7 +367,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [\hich\af2\dbch\af31505\loch\f2 -Log] [-Logging] [-MachineCatalogs] [-MaxDetails] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [-Log] [-Logging]\hich\af2\dbch\af31505\loch\f2  [-MachineCatalogs] [-MaxDetails] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
@@ -375,7 +375,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTe\hich\af2\dbch\af31505\loch\f2 sting\\XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 
@@ -1114,11 +1114,11 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4213396 .}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid595465 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8350100\charrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: December 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid595465 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
-\hich\af2\dbch\af31505\loch\f2 , 2018
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 January}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
+\hich\af2\dbch\af31505\loch\f2  2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid595465 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 , 201}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1956,10 +1956,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000b0fc
-2294379dd40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000b0fc2294379dd401
-b0fc2294379dd40100000000000000000000000044005900d400d5004300d300c000c80054004500340053005400ca0055005a00c200d10046004f005400d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000b0fc2294379d
-d401b0fc2294379dd4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000c00c
+d8e07ab5d40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000c00cd8e07ab5d401
+c00cd8e07ab5d401000000000000000000000000420044004200d000c1005000d600dc00c700d400ca005300cb00de004a004c0044004e00de00ca004100d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000c00cd8e07ab5
+d401c00cd8e07ab5d4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1967,7 +1967,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b30423335384430442d323833382d343734432d393234452d4135313938423131344534467d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b38343730333030342d424346442d344139462d393241462d4532344230434446414130337d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -75,16 +75,16 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid205773\rsid219208\rsid265763\rsid346080\rsid595465\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2579094
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid265763\rsid346080\rsid595465\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2579094
 \rsid2584542\rsid2902416\rsid2978753\rsid3300860\rsid3430394\rsid3542051\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229
-\rsid7733837\rsid7763859\rsid8350100\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12258164\rsid12271374
-\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14697282\rsid14828264\rsid14881286\rsid15613047\rsid15623927\rsid15678052
-\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0
-\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo1\dy26\hr7\min27}{\version61}{\edmins11795}{\nofpages28}{\nofwords8859}{\nofchars50498}{\nofcharsws59239}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas.microsof
-t.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid7733837\rsid7763859\rsid7881433\rsid8350100\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12258164
+\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14697282\rsid14828264\rsid14881286\rsid15613047\rsid15623927
+\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440
+\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo1\dy26\hr7\min54}{\version62}{\edmins11819}{\nofpages28}{\nofwords8852}{\nofchars50459}{\nofcharsws59193}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas
+.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYYGtQASRr7lLQAAAA==}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale109\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYaGtQBTd6X8LQAAAA==}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -190,14 +190,14 @@ Orchestration_PowerShellSnapIn_x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 C:\\X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866 
-\hich\af37\dbch\af31505\loch\f37 D7Scri\hich\af37\dbch\af31505\loch\f37 pt}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\hich\af37\dbch\af31505\loch\f37 D7Scr\hich\af37\dbch\af31505\loch\f37 ipt}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid14881286\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Close your Internet browser.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 b.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -230,7 +230,7 @@ WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e000000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e00000000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
 . The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 
@@ -238,16 +238,16 @@ WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\
 \f37\fs22\lang1024\langfe1024\noproof\insrsid9112866\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 remote}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16326917 
-\par \hich\af37\dbch\af31505\loch\f37 Scout 3.x no longer installs the Citrix.GroupPol\hich\af37\dbch\af31505\loch\f37 icy.Commands.psm1 file.
+\par \hich\af37\dbch\af31505\loch\f37 Scou\hich\af37\dbch\af31505\loch\f37 t 3.x no longer installs the Citrix.GroupPolicy.Commands.psm1 file.
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid205773 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid205773 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid205773 \hich\af37\dbch\af31505\loch\f37 
- The Citrix Group Policy PowerShell module will not load from an elevated PowerShell session. If the module is manually imported, the module is not detected from an elevated PowerShell session.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid205773\charrsid205773 
+ The Citrix Group Policy PowerShell module will not load from an elevated PowerShell session. If the module is manually imported, the module is not detected from an elevated PowerShe\hich\af37\dbch\af31505\loch\f37 ll session.}{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid205773\charrsid205773 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid16597410 \hich\af43\dbch\af31505\loch\f43 
 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid11488686 \hich\af43\dbch\af31505\loch\f43 How to use this sc\hich\af43\dbch\af31505\loch\f43 ript?
+\ltrch\fcs0 \insrsid11488686 \hich\af43\dbch\af31505\loch\f43 How to use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 
@@ -290,7 +290,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \hich\af37\dbch\af31505\loch\f37 -AdminAddress DDCName }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full he\hich\af37\dbch\af31505\loch\f37 lp text is available.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8876191 
 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
@@ -299,35 +299,38 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af43\dbch\af31505\loch\f43 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8876191 
-\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8350100 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\
-XD7_Inventory_V2.ps1 -full
+\par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8350100 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 PS C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 > get-help .\\XD7_Inventory_V2.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix Xen\hich\af2\dbch\af31505\loch\f2 Desktop 7.8+ Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-MSWord] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-MSWord] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-Compa\hich\af2\dbch\af31505\loch\f2 nyFax <String>] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <S\hich\af2\dbch\af31505\loch\f2 tring>] [-CompanyEmail <String>] [-CompanyFax <String>] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs]\hich\af2\dbch\af31505\loch\f2 
- [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosti\hich\af2\dbch\af31505\loch\f2 
+ng] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] [-VDARegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-HTML] \hich\af2\dbch\af31505\loch\f2 [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Administrators] [-AppDisks] [-Applications] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-BrokerRegistryKeys] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -346,7 +349,8 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-VDARegistryKeys] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL]
 \par \hich\af2\dbch\af31505\loch\f2     -From <String> \hich\af2\dbch\af31505\loch\f2 -To <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]\hich\af2\dbch\af31505\loch\f2 
@@ -358,7 +362,8 @@ XD7_Inventory_V2.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-StoreFront] [-VDARegist\hich\af2\dbch\af31505\loch\f2 ryKeys] [<CommonParameters>]
 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-Compa\hich\af2\dbch\af31505\loch\f2 
@@ -375,7 +380,8 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 
@@ -1052,7 +1058,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -1060,37 +1066,37 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The default is 25.
+\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Speci\hich\af2\dbch\af31505\loch\f2 fies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used,\hich\af2\dbch\af31505\loch\f2  this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is \hich\af2\dbch\af31505\loch\f2 a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1099,10 +1105,10 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         This cmd\hich\af2\dbch\af31505\loch\f2 let supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.micro\hich\af2\dbch\af31505\loch\f2 soft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/\hich\af2\dbch\af31505\loch\f2 fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
@@ -1125,13 +1131,13 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USE\hich\af2\dbch\af31505\loch\f2 R\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\S\hich\af2\dbch\af31505\loch\f2 oftware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for \hich\af2\dbch\af31505\loch\f2 the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the\hich\af2\dbch\af31505\loch\f2  Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
@@ -1635,7 +1641,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1643,12 +1649,12 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to sen\hich\af2\dbch\af31505\loch\f2 d email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send\hich\af2\dbch\af31505\loch\f2  email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1659,7 +1665,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 31 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webste\hich\af2\dbch\af31505\loch\f2 r@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster\hich\af2\dbch\af31505\loch\f2 @CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1793,7 +1799,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks            = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = Tr\hich\af2\dbch\af31505\loch\f2 ue
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
-\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys         = True
+\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys \hich\af2\dbch\af31505\loch\f2     = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
@@ -1956,10 +1962,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000c00c
-d8e07ab5d40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000c00cd8e07ab5d401
-c00cd8e07ab5d401000000000000000000000000420044004200d000c1005000d600dc00c700d400ca005300cb00de004a004c0044004e00de00ca004100d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000c00cd8e07ab5
-d401c00cd8e07ab5d4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000060be
+b8b47eb5d40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000060beb8b47eb5d401
+60beb8b47eb5d401000000000000000000000000c70042004300ce00450055004a00c3004700d400ce004200420043004200cf00ca00c70043003200c900c0003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000060beb8b47eb5
+d40160beb8b47eb5d4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1967,7 +1973,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b38343730333030342d424346442d344139462d393241462d4532344230434446414130337d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b31314145313039432d363334322d344231422d383130342d3230364641413730394341367d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,19 +1,19 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f63\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f64\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f65\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f67\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f68\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f69\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f70\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f71\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f72\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f414\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f415\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f417\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f418\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\f419\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f420\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f421\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f422\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
-{\f474\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f475\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f477\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f478\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
-{\f481\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f482\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f438\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f439\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f441\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f442\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f443\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f444\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f445\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f446\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f458\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f459\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
+{\f461\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f462\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f463\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f464\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
+{\f465\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f466\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f778\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f779\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f781\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f782\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f785\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f786\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\f808\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f809\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f811\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f812\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\f813\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f814\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f815\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f816\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
+{\f1068\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f1069\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f1071\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f1072\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
+{\f1075\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f1076\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -37,17 +37,17 @@
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
 \red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red230\green230\blue230;
 \red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
-\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
-\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
-heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
+\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
+\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
+heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
+\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
+\fs24\lang1033\langfe1033\loch\f63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid16597410 FollowedHyperlink;}{\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext20 \sqformat \spriority1 \styrsid8394203 No Spacing;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext20 \sqformat \spriority1 \styrsid8394203 No Spacing;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
 \cf15\chshdng0\chcfpat0\chcbpat20 \sbasedon10 \ssemihidden \sunhideused \styrsid16271519 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
 {\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
@@ -77,21 +77,21 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid265763\rsid346080\rsid595465\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2579094
 \rsid2584542\rsid2902416\rsid2978753\rsid3300860\rsid3430394\rsid3542051\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229
-\rsid7733837\rsid7763859\rsid7881433\rsid8350100\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11488686\rsid11823514\rsid12258164
-\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14697282\rsid14828264\rsid14881286\rsid15613047\rsid15623927
-\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440
-\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo1\dy26\hr7\min54}{\version62}{\edmins11819}{\nofpages28}{\nofwords8852}{\nofchars50459}{\nofcharsws59193}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas
-.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid7733837\rsid7763859\rsid7881433\rsid8350100\rsid8394203\rsid8410782\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723\rsid9639341\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11041950\rsid11488686\rsid11823514
+\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14697282\rsid14828264\rsid14881286\rsid15613047
+\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
+\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo2\dy1\hr7\min32}{\version63}{\edmins11820}{\nofpages28}{\nofwords8852}{\nofchars50459}{\nofcharsws59193}{\vern87}}
+{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale109\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYaGtQBTd6X8LQAAAA==}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Xen}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf21\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 Desktop 7.x}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid928241 
-\hich\af43\dbch\af31505\loch\f43 2}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af63\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af63\dbch\af31505\loch\f63 Xen}{\rtlch\fcs1 \ab\af63\afs28 \ltrch\fcs0 
+\b\fs28\cf21\insrsid16517051 \hich\af63\dbch\af31505\loch\f63 Desktop 7.x}{\rtlch\fcs1 \ab\af63\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af63\dbch\af31505\loch\f63  Version }{\rtlch\fcs1 \ab\af63\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid928241 
+\hich\af63\dbch\af31505\loch\f63 2}{\rtlch\fcs1 \ab\af63\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af63\dbch\af31505\loch\f63  Documentation Script ReadMe
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5267713 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: This script requires PowerShell V3 or later.
 
@@ -99,11 +99,11 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 
 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37  supported.}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid4357927 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37 \ltrch\fcs0 \f37\insrsid5267713 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af63\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af63\dbch\af31505\loch\f63 Support for non-English Versions of Microsoft Word
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Catalan}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid8662784 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8662784 \hich\af37\dbch\af31505\loch\f37 Chinese}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8662784\charrsid13987238 
@@ -119,13 +119,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Spanish
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Swedish
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid9112866 
-\hich\af43\dbch\af31505\loch\f43 Prerequisites
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af63\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid9112866 
+\hich\af63\dbch\af31505\loch\f63 Prerequisites
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a XenDesktop 7.\hich\af37\dbch\af31505\loch\f37 
 x Site, let us ensure we have the necessary requirements.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 If the script will be run remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 there are two choices: install }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Citrix Studio }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 or manually install the PowerShell snapins.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -190,7 +190,7 @@ Orchestration_PowerShellSnapIn_x??
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 
 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -210,7 +210,7 @@ Current\\Utilities
 \hich\af37\dbch\af31505\loch\f37 Utilities
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
-If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
+If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af63\dbch\af31505\loch\f63  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
@@ -218,7 +218,7 @@ If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \lt
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are running 64-bit Windows, }{
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6637724 \hich\af37\dbch\af31505\loch\f37 follow Step C and also }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 copy the file}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{
+\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af63\dbch\af31505\loch\f63  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\
 WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 
 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
@@ -230,26 +230,26 @@ WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e00000000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
-. The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 
-\hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\lang1024\langfe1024\noproof\insrsid9112866\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 remote}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+. The XenApp 6.5 file is from S\hich\af37\dbch\af31505\loch\f37 eptember 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+ the updated version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid9112866\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 remote}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  Controller.}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16326917 
-\par \hich\af37\dbch\af31505\loch\f37 Scou\hich\af37\dbch\af31505\loch\f37 t 3.x no longer installs the Citrix.GroupPolicy.Commands.psm1 file.
+\par \hich\af37\dbch\af31505\loch\f37 Scout 3.x no longer installs the Ci\hich\af37\dbch\af31505\loch\f37 trix.GroupPolicy.Commands.psm1 file.
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid205773 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid205773 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid205773 \hich\af37\dbch\af31505\loch\f37 
- The Citrix Group Policy PowerShell module will not load from an elevated PowerShell session. If the module is manually imported, the module is not detected from an elevated PowerShe\hich\af37\dbch\af31505\loch\f37 ll session.}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid205773\charrsid205773 
+ The Citrix Group Policy PowerShell module will not load from an elevated PowerShell session. If the module is manually imported, the module is not detected from an elevated PowerShell session.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid205773\charrsid205773 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid16597410 \hich\af43\dbch\af31505\loch\f43 
+\fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af63\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid16597410 \hich\af63\dbch\af31505\loch\f63 
 Script Usage
-\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid11488686 \hich\af43\dbch\af31505\loch\f43 How to use this script?
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
+\ltrch\fcs0 \insrsid11488686 \hich\af63\dbch\af31505\loch\f63 How t\hich\af63\dbch\af31505\loch\f63 o use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \ai\af37\afs22 
 \ltrch\fcs0 \i\f37\fs22\insrsid8876191 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -279,25 +279,25 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid16517051 
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 To }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 run}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37  the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid11488686\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 script }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\lang1024\langfe1024\noproof\insrsid2054605 \hich\af37\dbch\af31505\loch\f37 on}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37  a remote Controller:
 \par }\pard\plain \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 .\\\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 .\\\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid8876191 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 
 \hich\af37\dbch\af31505\loch\f37 -AdminAddress DDCName }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full he\hich\af37\dbch\af31505\loch\f37 lp text is available.
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8876191 
 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af43\dbch\af31505\loch\f43 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
-\par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8394203 \page \hich\af63\dbch\af31505\loch\f63 Help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
+\par }\pard\plain \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8394203 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af63\hich\af63\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8876191 
 \par }\pard \ltrpar\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8350100 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 PS C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 > get-help .\\XD7_Inventory_V2.ps1 -full
@@ -307,30 +307,30 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+ Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.8+\hich\af2\dbch\af31505\loch\f2  Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory_V2.ps1 [-MSWord] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <S\hich\af2\dbch\af31505\loch\f2 tring>] [-CompanyEmail <String>] [-CompanyFax <String>] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosti\hich\af2\dbch\af31505\loch\f2 
-ng] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] [-VDARegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory_V2.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+XD7_Inventory_V2.ps1 [-HTML] [-MSWord] [-PDF] [-Text]\hich\af2\dbch\af31505\loch\f2  [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Administrators] [-AppDisks] [-Applications] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-BrokerRegistryKeys] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -353,8 +353,8 @@ XD7_Inventory_V2.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fc
 XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]\hich\af2\dbch\af31505\loch\f2 
- [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-End\hich\af2\dbch\af31505\loch\f2 
+Date <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
@@ -366,13 +366,13 @@ XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\af
 XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-Compa\hich\af2\dbch\af31505\loch\f2 
-nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax \hich\af2\dbch\af31505\loch\f2 
+<String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [-Log] [-Logging]\hich\af2\dbch\af31505\loch\f2  [-MachineCatalogs] [-MaxDetails] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] [-Max\hich\af2\dbch\af31505\loch\f2 Details] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
@@ -381,7 +381,7 @@ nyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7881433 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
+XD7_Inventory_V2.ps1 [-Text] [-AddDateTim\hich\af2\dbch\af31505\loch\f2 e] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-AppDisks] [-Applications] [-BrokerRegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 
@@ -446,7 +446,7 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following la\hich\af2\dbch\af31505\loch\f2 nguage versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -458,19 +458,19 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<Swi\hich\af2\dbch\af31505\loch\f2 tchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
@@ -484,52 +484,52 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word Save\hich\af2\dbch\af31505\loch\f2 As PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text \hich\af2\dbch\af31505\loch\f2 file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2019 at 6PM is 2019-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2019-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         O\hich\af2\dbch\af31505\loch\f2 utput filename will be ReportName_2019-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controll\hich\af2\dbch\af31505\loch\f2 er the PowerShell snapins will connect
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect
 \par \hich\af2\dbch\af31505\loch\f2         to.
-\par \hich\af2\dbch\af31505\loch\f2         This can be provided as a hostname or an IP address.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This can be provided as a hostname or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to Localhost.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Localhost
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value    \hich\af2\dbch\af31505\loch\f2             Localhost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -540,24 +540,24 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AppDisks [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all AppDisks.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by defau\hich\af2\dbch\af31505\loch\f2 lt.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AD.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed i\hich\af2\dbch\af31505\loch\f2 nformation for all applications.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
 \par 
@@ -568,29 +568,29 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -BrokerRegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registr\hich\af2\dbch\af31505\loch\f2 y keys to the Controller section.
+\par \hich\af2\dbch\af31505\loch\f2         Adds information on 315 registry keys to the Controller section.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights pages, per Controller, to the report.
+\par \hich\af2\dbch\af31505\loch\f2         For Word and PDF output, this adds eights p\hich\af2\dbch\af31505\loch\f2 ages, per Controller, to the report.
 \par \hich\af2\dbch\af31505\loch\f2         For Text and HTML, this adds 315 lines, per Controller, to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter has an alias of BRK.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of BRK.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the \hich\af2\dbch\af31505\loch\f2 Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
@@ -601,23 +601,23 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2                 Facet \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
@@ -630,20 +630,20 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cove\hich\af2\dbch\af31505\loch\f2 r Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD a\hich\af2\dbch\af31505\loch\f2 nd PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -657,27 +657,27 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Posit\hich\af2\dbch\af31505\loch\f2 ion?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supp\hich\af2\dbch\af31505\loch\f2 orted.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word\hich\af2\dbch\af31505\loch\f2  en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin \hich\af2\dbch\af31505\loch\f2 (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 \hich\af2\dbch\af31505\loch\f2 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
@@ -686,24 +686,24 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 man\hich\af2\dbch\af31505\loch\f2 ually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 20\hich\af2\dbch\af31505\loch\f2 10/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word \hich\af2\dbch\af31505\loch\f2 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
@@ -1122,9 +1122,8 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 January}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
-\hich\af2\dbch\af31505\loch\f2  2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid595465 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2 , 201}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11041950 \hich\af2\dbch\af31505\loch\f2 February 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
+\hich\af2\dbch\af31505\loch\f2 , 201}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14097372 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1319,12 +1318,12 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no C\hich\af2\dbch\af31505\loch\f2 itrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1332,20 +1331,20 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS \hich\af2\dbch\af31505\loch\f2 C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V\hich\af2\dbch\af31505\loch\f2 2.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 yName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the U\hich\af2\dbch\af31505\loch\f2 ser Name.
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Administrators
@@ -1358,7 +1357,7 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1367,16 +1366,16 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/\hich\af2\dbch\af31505\loch\f2 2019
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate 01/01/2019
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate 01/31/2019
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/2019 through
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Creates a report with Configuration Logging details for the dates 01/01/2019 through
 \par \hich\af2\dbch\af31505\loch\f2     01/31/2019.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     W\hich\af2\dbch\af31505\loch\f2 ebster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1386,25 +1385,25 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMP\hich\af2\dbch\af31505\loch\f2 LE 17 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2019 10:00:00"
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate "06/01/2019 14:00:00"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the t\hich\af2\dbch\af31505\loch\f2 ime range
-\par \hich\af2\dbch\af31505\loch\f2     06/01/2019 10:00:00AM through 06/01/2019 02:00:00PM.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
+\par \hich\af2\dbch\af31505\loch\f2     06/01/2019 10:00:00AM \hich\af2\dbch\af31505\loch\f2 through 06/01/2019 02:00:00PM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for \hich\af2\dbch\af31505\loch\f2 the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
@@ -1415,13 +1414,13 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections, and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1431,11 +1430,11 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  report with full details for StoreFront.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1447,21 +1446,21 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C\hich\af2\dbch\af31505\loch\f2 :\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -Deliv\hich\af2\dbch\af31505\loch\f2 eryGroups
 \par \hich\af2\dbch\af31505\loch\f2     -Applications -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 pplications
+\par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
+\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connectio\hich\af2\dbch\af31505\loch\f2 ns, and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwar\hich\af2\dbch\af31505\loch\f2 e\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1472,22 +1471,22 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE \hich\af2\dbch\af31505\loch\f2 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
-\par \hich\af2\dbch\af31505\loch\f2         Application\hich\af2\dbch\af31505\loch\f2 s
+\par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
-\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
+\par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, a\hich\af2\dbch\af31505\loch\f2 nd Resources
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admi\hich\af2\dbch\af31505\loch\f2 nistrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1496,29 +1495,29 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster f\hich\af2\dbch\af31505\loch\f2 or the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "M\hich\af2\dbch\af31505\loch\f2 od"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
-\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the \hich\af2\dbch\af31505\loch\f2 AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 24 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
@@ -1529,22 +1528,22 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. W\hich\af2\dbch\af31505\loch\f2 atson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, Londo\hich\af2\dbch\af31505\loch\f2 n, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -Compan\hich\af2\dbch\af31505\loch\f2 yName "Sherlock Holmes Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Wat\hich\af2\dbch\af31505\loch\f2 son for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par 
@@ -1552,22 +1551,22 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HH\hich\af2\dbch\af31505\loch\f2 mm.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2019 at 6PM is 2019-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2019-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     Output filename \hich\af2\dbch\af31505\loch\f2 will be XD7SiteName_2019-06-01_1800.docx
 \par 
 \par 
 \par 
@@ -1576,8 +1575,8 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will us\hich\af2\dbch\af31505\loch\f2 e all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1587,9 +1586,9 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd\hich\af2\dbch\af31505\loch\f2 _HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2019 at 6PM is 2019-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2019-06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_2019-06-01_1800.pdf
 \par 
 \par 
 \par 
@@ -1602,8 +1601,8 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use \hich\af2\dbch\af31505\loch\f2 all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1617,16 +1616,16 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\Sh\hich\af2\dbch\af31505\loch\f2 areName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administr\hich\af2\dbch\af31505\loch\f2 ator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page fo\hich\af2\dbch\af31505\loch\f2 rmat.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
@@ -1641,20 +1640,20 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send\hich\af2\dbch\af31505\loch\f2  email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1662,25 +1661,25 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8350100 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 31 --------------------------
+\f2\fs18\insrsid8350100\charrsid8350100 \hich\af2\dbch\af31505\loch\f2  ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 31 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster\hich\af2\dbch\af31505\loch\f2 @CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the cu\hich\af2\dbch\af31505\loch\f2 rrent user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1690,10 +1689,10 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1706,18 +1705,18 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\XD7_Inventory_V2.ps1 -Section Groups -DG
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     W\hich\af2\dbch\af31505\loch\f2 ebster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Pro\hich\af2\dbch\af31505\loch\f2 cesses only the Delivery Groups section of the report with Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
 \par 
 \par 
 \par 
@@ -1735,25 +1734,25 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 35 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default va\hich\af2\dbch\af31505\loch\f2 lues.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compa\hich\af2\dbch\af31505\loch\f2 ny Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to the Controllers section.
@@ -1763,19 +1762,19 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 36 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -VDARegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory_V2.ps1 -VDARegistryKeys
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="C\hich\af2\dbch\af31505\loch\f2 arl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Adds t\hich\af2\dbch\af31505\loch\f2 he information on VDA registry keys to the Machine Details section.
-\par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to $True
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to the Machine Details section.
+\par \hich\af2\dbch\af31505\loch\f2     Forces the\hich\af2\dbch\af31505\loch\f2  MachineCatalogs parameter to $True
 \par 
 \par 
 \par 
@@ -1785,30 +1784,30 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administ\hich\af2\dbch\af31505\loch\f2 rator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks            = True
-\par \hich\af2\dbch\af31505\loch\f2         Applications        = Tr\hich\af2\dbch\af31505\loch\f2 ue
+\par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         BrokerRegistryKeys  = True
-\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys \hich\af2\dbch\af31505\loch\f2     = True
-\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
+\par \hich\af2\dbch\af31505\loch\f2         Deliver\hich\af2\dbch\af31505\loch\f2 yGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Policies            = True
+\par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
+\par \hich\af2\dbch\af31505\loch\f2         NoPolicies       \hich\af2\dbch\af31505\loch\f2    = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
 \par 
@@ -1816,26 +1815,26 @@ XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 [-Text] [-AddDateTime] [-Adm
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 38 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Web\hich\af2\dbch\af31505\loch\f2 ster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV2InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up\hich\af2\dbch\af31505\loch\f2  to the last 250 errors reported by the script.
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV2InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV2InventoryScriptInfo_yyy\hich\af2\dbch\af31505\loch\f2 y-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 XDV2DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
+\par \hich\af2\dbch\af31505\loch\f2     XDV2DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
 \par 
 \par 
@@ -1962,10 +1961,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000060be
-b8b47eb5d40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000060beb8b47eb5d401
-60beb8b47eb5d401000000000000000000000000c70042004300ce00450055004a00c3004700d400ce004200420043004200cf00ca00c70043003200c900c0003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000060beb8b47eb5
-d40160beb8b47eb5d4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000f05f
+7d8332bad40103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000f05f7d8332bad401
+f05f7d8332bad401000000000000000000000000da00d90044004a00330051005700c500c400c4003400300049005400d000df00560032004600d7004b00c0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000f05f7d8332ba
+d401f05f7d8332bad4010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1973,7 +1972,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b31314145313039432d363334322d344231422d383130342d3230364641413730394341367d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b37354339393045422d413530352d343739322d394132312d3343334635354331373732417d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,19 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.21
+#	Added License Server version
+#	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
+#	Added test to catch multiple output parameters used
+#	Added the restart schedule "Frequency notification" to Delivery Group details
+#	Changed in Function Get-IPAddress, the Catch value from $Null to "Unable to resolve IP address"
+#	Fixed, in Functions OutputDesktopOSMachine and OutputServerOSMachine, the output of users
+#	Fixed bug in Function ProcessHosting where the comparison for $Hypervisor.Name was done incorrectly
+#	Fixed in Delivery Groups details to handle multiple Desktop Entitlements and multiple Restart Schedules
+#	Fixed in Function OutputControllerRegistryKeys, added a blank line after the Word table
+#	For Application details changed "Description" to "Description and keywords"
+#	In the Delivery Controllers section added a blank line after the Word and HTML tables
+
 #Version 2.20.2 26-Dec-2018
 #	Fixed Function OutputAppendixA to fix duplicate VDA registry lines
 

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,7 +3,10 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
-#Version 2.21
+#Version 2.21 1-Feb-2019
+#	Added additional VDA registry key data to Machine details for Local Text Echo added back in VDA 1811
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\UseDirect3D
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\PresentDevice
 #	Added License Server version
 #	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
 #	Added test to catch multiple output parameters used


### PR DESCRIPTION
#Version 2.21 1-Feb-2019
#	Added additional VDA registry key data to Machine details for Local Text Echo added back in VDA 1811
#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\UseDirect3D
#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\PresentDevice
#	Added License Server version
#	Added missing data in the hosting section for Networks, Standard Storage, Personal vDisk Storage, and Temporary Storage
#	Added test to catch multiple output parameters used
#	Added the restart schedule "Frequency notification" to Delivery Group details
#	Changed in Function Get-IPAddress, the Catch value from $Null to "Unable to resolve IP address"
#	Fixed, in Functions OutputDesktopOSMachine and OutputServerOSMachine, the output of users
#	Fixed bug in Function ProcessHosting where the comparison for $Hypervisor.Name was done incorrectly
#	Fixed in Delivery Groups details to handle multiple Desktop Entitlements and multiple Restart Schedules
#	Fixed in Function OutputControllerRegistryKeys, added a blank line after the Word table
#	For Application details changed "Description" to "Description and keywords"
#	In the Delivery Controllers section added a blank line after the Word and HTML tables
