### PR TITLE
2.30

### DIFF
--- a/2.29ReadMe.md
+++ b/2.29ReadMe.md
@@ -1,7 +1,0 @@
-#Version 2.29 17-Dec-2019
-#	Fix Swedish Table of Contents (Thanks to Johan Kallio)
-#		From 
-#			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
-#		To
-#			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
-#	Updated help text

--- a/2.30ReadMe.md
+++ b/2.30ReadMe.md
@@ -1,0 +1,7 @@
+#Version 2.30 19-Dec-2019
+#	Added additional VDA registry key data to Machine details for VDA 1912 (Known Issues for ADM hardware encoding)
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\MaxNumRefFrames
+#	Fixed - FINALLY - the issue of detecting the Site Version for comparison.
+#		CVAD 1909 and above show Multi-session OS and Single-session OS
+#		CVAD 1906 and below show Server OS and Desktop OS
+#	Tested with CVAD 1912

--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -1038,9 +1038,9 @@
 	This script creates a Word, PDF, plain text, or HTML document.
 .NOTES
 	NAME: XD7_Inventory_V2.ps1
-	VERSION: 2.29
+	VERSION: 2.30
 	AUTHOR: Carl Webster
-	LASTEDIT: December 17, 2019
+	LASTEDIT: December 19, 2019
 #>
 
 #endregion
@@ -1249,6 +1249,14 @@ Param(
 
 # This script is based on the 1.20 script
 
+#Version 2.30 19-Dec-2019
+#	Added additional VDA registry key data to Machine details for VDA 1912 (Known Issues for ADM hardware encoding)
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\MaxNumRefFrames
+#	Fixed - FINALLY - the issue of detecting the Site Version for comparison.
+#		CVAD 1909 and above show Multi-session OS and Single-session OS
+#		CVAD 1906 and below show Server OS and Desktop OS
+#	Tested with CVAD 1912
+#	
 #Version 2.29 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -6808,7 +6816,7 @@ Function OutputMachines
 		#updated for CVAD 1909 in V2.28
 		If($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "SingleSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS"
 			}
@@ -6820,7 +6828,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "MultiSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Multi-session OS"
 			}
@@ -6832,7 +6840,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $False -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "SingleSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS (Virtual)"
 			}
@@ -6844,7 +6852,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $False -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "MultiSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Multi-session OS (Virtual)"
 			}
@@ -6856,7 +6864,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $True)
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS (Remote PC Access)"
 			}
@@ -6983,7 +6991,7 @@ Function OutputMachines
 		#updated for CVAD 1909 in V2.28
 		If($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "SingleSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS"
 			}
@@ -6994,7 +7002,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "MultiSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Multi-session OS"
 			}
@@ -7005,7 +7013,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $False -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "SingleSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS (Virtual)"
 			}
@@ -7016,7 +7024,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $False -and $Catalog.IsRemotePC -eq $False -and $Catalog.SessionSupport -eq "MultiSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Multi-session OS (Virtual)"
 			}
@@ -7027,7 +7035,7 @@ Function OutputMachines
 		}
 		ElseIf($Catalog.MachinesArePhysical -eq $True -and $Catalog.IsRemotePC -eq $True)
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xCatalogType = "Single-session OS (Remote PC Access)"
 			}
@@ -8651,6 +8659,8 @@ Function GetVDARegistryKeys
 		#added in V2.21 for Local Text Echo added back in VDA 1811
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "UseDirect3D" $ComputerName $xType
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "PresentDevice" $ComputerName $xType
+		#added in V2.30 for VDA 1912 (Known Issues for ADM hardware encoding)
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "MaxNumRefFrames" $ComputerName $xType
 		
 		#From the 1811 docs
 		Get-VDARegKeyToObject "HKLM:\System\Currentcontrolset\services\picadm\Parameters" "DisableFullStreamWrite" $ComputerName $xType
@@ -8727,6 +8737,8 @@ Function GetVDARegistryKeys
 		#added in V2.21 for Local Text Echo added back in VDA 1811
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "UseDirect3D" $ComputerName $xType
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "PresentDevice" $ComputerName $xType
+		#added in V2.30 for VDA 1912 (Known Issues for ADM hardware encoding)
+		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender" "MaxNumRefFrames" $ComputerName $xType
 		
 		#From What's New and Fixed in 7.18
 		Get-VDARegKeyToObject "HKLM:\SOFTWARE\Citrix\Citrix Virtual Desktop Agent" "DisableLogonUISuppression" $ComputerName $xType
@@ -10630,7 +10642,7 @@ Function OutputDeliveryGroupTable
 		#updated for CVAD 1909 in V2.28
 		If($Group.SessionSupport -eq "SingleSession")
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xSingleSession = "Single-session OS"
 			}
@@ -10641,7 +10653,7 @@ Function OutputDeliveryGroupTable
 		}
 		Else
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$xSingleSession = "Multi-session OS"
 			}
@@ -10788,7 +10800,7 @@ Function OutputDeliveryGroup
 	#updated for CVAD 1909 in V2.28
 	If($Group.SessionSupport -eq "SingleSession")
 	{
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			$xSingleSession = "Single-session OS"
 		}
@@ -10799,7 +10811,7 @@ Function OutputDeliveryGroup
 	}
 	Else
 	{
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			$xSingleSession = "Multi-session OS"
 		}
@@ -33393,7 +33405,7 @@ Function OutputHosting
 			OutputWarning $txt
 		}
 
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			Write-Verbose "$(Get-Date): `tProcessing Single-session OS Data"
 		}
@@ -33410,7 +33422,7 @@ Function OutputHosting
 			If($MSWord -or $PDF)
 			{
 				$Selection.InsertNewPage()
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					WriteWordLine 4 0 "Single-session OS Machines ($($cnt))"
 				}
@@ -33421,7 +33433,7 @@ Function OutputHosting
 			}
 			ElseIf($Text)
 			{
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					Line 0 "Single-session OS Machines ($($cnt))"
 				}
@@ -33433,7 +33445,7 @@ Function OutputHosting
 			}
 			ElseIf($HTML)
 			{
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					WriteHTMLLine 4 0 "Single-session OS Machines ($($cnt))"
 				}
@@ -33450,7 +33462,7 @@ Function OutputHosting
 		}
 		ElseIf($? -and ($Null -eq $DesktopOSMachines))
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$txt = "There are no Single-session OS Machines"
 			}
@@ -33462,7 +33474,7 @@ Function OutputHosting
 		}
 		Else
 		{
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$txt = "Unable to retrieve Single-session OS Machines"
 			}
@@ -33474,7 +33486,7 @@ Function OutputHosting
 		}
 
 		#updated for CVAD 1909 in V2.28
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			Write-Verbose "$(Get-Date): `tProcessing Multi-session OS Data"
 		}
@@ -33492,7 +33504,7 @@ Function OutputHosting
 			{
 				$Selection.InsertNewPage()
 				#updated for CVAD 1909 in V2.28
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					WriteWordLine 4 0 "Mlti-session OS Machines ($($cnt))"
 				}
@@ -33505,7 +33517,7 @@ Function OutputHosting
 			{
 				Line 0 ""
 				#updated for CVAD 1909 in V2.28
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					Line 0 "Multi-session OS Machines ($($cnt))"
 				}
@@ -33518,7 +33530,7 @@ Function OutputHosting
 			ElseIf($HTML)
 			{
 				#updated for CVAD 1909 in V2.28
-				If($Script:XDSiteVersion -ge "1909")
+				If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 				{
 					WriteHTMLLine 4 0 "Multi-session OS Machines ($($cnt))"
 				}
@@ -33536,7 +33548,7 @@ Function OutputHosting
 		ElseIf($? -and ($Null -eq $ServerOSMachines))
 		{
 			#updated for CVAD 1909 in V2.28
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$txt = "There are no Multi-session OS Machines"
 			}
@@ -33549,7 +33561,7 @@ Function OutputHosting
 		Else
 		{
 			#updated for CVAD 1909 in V2.28
-			If($Script:XDSiteVersion -ge "1909")
+			If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 			{
 				$txt = "Unable to retrieve Multi-session OS Machines"
 			}
@@ -35198,7 +35210,7 @@ Function ProcessSummaryPage
 		$ScriptInformation = New-Object System.Collections.ArrayList
 		WriteWordLine 4 0 "Machine Catalogs"
 		#updated for CVAD 1909 in V2.28
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			$ScriptInformation.Add(@{Data = "Total Multi-session OS Catalogs"; Value = $Script:TotalServerOSCatalogs.ToString(); }) > $Null
 			$ScriptInformation.Add(@{Data = 'Total Single-session OS Catalogs'; Value = $Script:TotalDesktopOSCatalogs.ToString(); }) > $Null
@@ -35496,7 +35508,7 @@ Function ProcessSummaryPage
 		Write-Verbose "$(Get-Date): `tAdd Machine Catalog summary info"
 		Line 0 "Machine Catalogs"
 		#updated for CVAD 1909 in V2.28
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			Line 1 "Total Multi-session OS Catalogs`t: " $Script:TotalServerOSCatalogs
 			Line 1 "Total Single-session OS Catalogs: " $Script:TotalDesktopOSCatalogs
@@ -35589,7 +35601,7 @@ Function ProcessSummaryPage
 		Write-Verbose "$(Get-Date): `tAdd Machine Catalog summary info"
 		$rowdata = @()
 		#updated for CVAD 1909 in V2.28
-		If($Script:XDSiteVersion -ge "1909")
+		If([Single]::Parse($Script:XDSiteVersion) -ge 1909)
 		{
 			$columnHeaders = @("Total Multi-session OS Catalogs",($global:htmlsb),$Script:TotalServerOSCatalogs.ToString(),$htmlwhite)
 			$rowdata += @(,('Total Single-session OS Catalogs',($global:htmlsb),$Script:TotalDesktopOSCatalogs.ToString(),$htmlwhite))
@@ -35987,6 +35999,7 @@ Function ProcessScriptSetup
 	$tmp = $Script:XDSiteVersion
 	Switch ($tmp)
 	{
+		"7.24"	{$Script:XDSiteVersion = "1912"}	#added in 2.30
 		"7.23"	{$Script:XDSiteVersion = "1909"}
 		"7.22"	{$Script:XDSiteVersion = "1906"}
 		"7.21"	{$Script:XDSiteVersion = "1903"}

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -79,23 +79,23 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1654655\rsid1857973\rsid2054605
-\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3300860\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4740061\rsid4925283\rsid4983150\rsid4993354\rsid5113752
-\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8876191\rsid9112866\rsid9338186\rsid9376723
-\rsid9520485\rsid9639341\rsid9708402\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11041950\rsid11227030\rsid11488686\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409
-\rsid12801149\rsid12863195\rsid12978708\rsid13401205\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14169246\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15428007\rsid15613047\rsid15623927\rsid15678052
-\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16203271\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
-\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy17\hr15\min12}{\version82}{\edmins11855}{\nofpages30}{\nofwords9227}{\nofchars52598}{\nofcharsws61702}{\vern119}}
-{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3097678\rsid3300860\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4740061\rsid4925283\rsid4983150\rsid4993354
+\rsid5113752\rsid5209339\rsid5267713\rsid6053627\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8876191\rsid9112866
+\rsid9338186\rsid9376723\rsid9520485\rsid9639341\rsid9708402\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10900280\rsid11041950\rsid11227030\rsid11488686\rsid11823514\rsid11884716\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992
+\rsid12541957\rsid12602409\rsid12801149\rsid12863195\rsid12978708\rsid13401205\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14169246\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15428007\rsid15613047
+\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16203271\rsid16207041\rsid16271519\rsid16272684\rsid16326917\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
+\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy19\hr15\min15}{\version83}{\edmins11856}{\nofpages30}{\nofwords9227}{\nofchars52598}
+{\nofcharsws61702}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYYmtQAWg9KBLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2517006 \chftnsep 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3097678 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2517006 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3097678 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2517006 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3097678 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2517006 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3097678 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -154,7 +154,7 @@ ess of the computer, from the full XenDesktop 7.x installation media, install th
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ADIdentity_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\\hich\af37\dbch\af31505\loch\f37 Analytics_PowerShell_SnapIn_x??
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\A\hich\af37\dbch\af31505\loch\f37 nalytics_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid6316284\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6316284 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\
 AppLibrary_PowerShell_SnapIn_x??
@@ -163,8 +163,8 @@ AppLibrary_PowerShell_SnapIn_x??
 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 v.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configuration_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citri
-\hich\af37\dbch\af31505\loch\f37 x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Del}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 egatedAdmin_PowerShellSnapIn_x??}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
@@ -207,7 +207,7 @@ Citrix Group Policy PowerShell module.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634b\hich\af37\dbch\af31505\loch\f37 4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -221,34 +221,35 @@ Citrix Group Policy PowerShell module.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 Copy the file from a Controller}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid16326917 \hich\af37\dbch\af31505\loch\f37  (only for 7.14 and earlier)}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 :
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 On a 32-bit Controller, go to %PROGRAMFILES%\\Citrix\\Scout\\
-Current\\Utilities
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 On a 32-bit Contr\hich\af37\dbch\af31505\loch\f37 
+oller, go to %PROGRAMFILES%\\Citrix\\Scout\\Current\\Utilities
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 ii.\tab}\hich\af37\dbch\af31505\loch\f37 On a 64-bit Controller, go to %PROGRAMFILES(x86)%\\Citrix\\Scout\\Current\\Utilities
 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
 If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
-\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
-, in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
-\hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\Sys\hich\af37\dbch\af31505\loch\f37 tem32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are running 64-bit Windows, }{
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6637724 \hich\af37\dbch\af31505\loch\f37 follow Step C and also }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 copy the file}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\
-WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 
-\hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.p
+\hich\af37\dbch\af31505\loch\f37 sm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 
+\hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 
+\ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 
+. This should be placed on the computer where the script is run.
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\bkmkend _Hlk504973097}
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  The Citrix.GroupPolicy.Commands.}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid9112866\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 ps\hich\af37\dbch\af31505\loch\f37 m1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
-\hich\af37\dbch\af31505\loch\f37  file is }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid9112866\charrsid2054605 \hich\af37\dbch\af31505\loch\f37 psm1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  file is }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
  the version that comes with XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16207041 \hich\af37\dbch\af31505\loch\f37 installed with XenDesktop 7.x or }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000000000000000003100110700ff008100004f00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000000000000000003100110700ff008100004f0000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
 . The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 
 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -281,8 +282,9 @@ Script Usage
 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, a Microsof\hich\af37\dbch\af31505\loch\f37 
-t Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
+By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
 PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
@@ -371,15 +373,15 @@ ompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String> -To <String>}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \\\hich\af2\dbch\af31505\loch\f2 XD
-\hich\af2\dbch\af31505\loch\f2 7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-BrokerRegistryKeys] [-Controllers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CSV] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Folder\hich\af2\dbch\af31505\loch\f2  <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String>] [-StartDate <DateTime>] [-StoreFront]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
@@ -387,37 +389,39 @@ ompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \\
-\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory_V2.ps1 [-PDF] [-AddDateTime] [-AdminAddress \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-BrokerRegistryKeys] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String\hich\af2\dbch\af31505\loch\f2 >] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-Controllers] [-CSV] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9520485 
+\f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-Controllers] [-\hich\af2\dbch\af31505\loch\f2 CSV] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Dev] [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Hosting] [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <\hich\af2\dbch\af31505\loch\f2 String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-StoreFront] [-UserName <String>] [-VDARegistryKeys] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 inAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-AppDisks]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-BrokerRegistryKeys] [-Controllers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
-
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Applications] [\hich\af2\dbch\af31505\loch\f2 -BrokerRegistryKeys] [-Controllers] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-CSV] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Hosting] [-Log] [-Logg\hich\af2\dbch\af31505\loch\f2 ing] [-MachineCatalogs] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-Hosting] [-Log] [-Logging] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-NoPolicies]\hich\af2\dbch\af31505\loch\f2  [-Policies] [-ScriptInfo] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 <String>] [-StartDate <DateTime>] [-StoreFront]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [-VDARegistryKeys] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
@@ -456,32 +460,32 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 livery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront
+\par \hich\af2\dbch\af31505\loch\f2         StoreF\hich\af2\dbch\af31505\loch\f2 ront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extreme\hich\af2\dbch\af31505\loch\f2 ly long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     t\hich\af2\dbch\af31505\loch\f2 ake an extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and\hich\af2\dbch\af31505\loch\f2  can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
+\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after\hich\af2\dbch\af31505\loch\f2  the XenDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the\hich\af2\dbch\af31505\loch\f2  following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
-\par \hich\af2\dbch\af31505\loch\f2         English
+\par \hich\af2\dbch\af31505\loch\f2         Engl\hich\af2\dbch\af31505\loch\f2 ish
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
@@ -498,16 +502,16 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value      \hich\af2\dbch\af31505\loch\f2           False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline i\hich\af2\dbch\af31505\loch\f2 nput?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -695,57 +699,57 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Posit\hich\af2\dbch\af31505\loch\f2 ion?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supp\hich\af2\dbch\af31505\loch\f2 orted.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages i\hich\af2\dbch\af31505\loch\f2 n Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin \hich\af2\dbch\af31505\loch\f2 (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in\hich\af2\dbch\af31505\loch\f2  2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Conse\hich\af2\dbch\af31505\loch\f2 rvative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date d\hich\af2\dbch\af31505\loch\f2 oesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 ma\hich\af2\dbch\af31505\loch\f2 nually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2\hich\af2\dbch\af31505\loch\f2 010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 20\hich\af2\dbch\af31505\loch\f2 13/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word\hich\af2\dbch\af31505\loch\f2  2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
@@ -756,22 +760,22 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         As of version 2.22, adds the follow\hich\af2\dbch\af31505\loch\f2 ing information to the Controllers section:
-\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft Hotfixes and Updates
+\par \hich\af2\dbch\af31505\loch\f2         As of version 2.22, adds the following information to the Controllers section:
+\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft H\hich\af2\dbch\af31505\loch\f2 otfixes and Updates
 \par \hich\af2\dbch\af31505\loch\f2                 List of Citrix installed components
 \par \hich\af2\dbch\af31505\loch\f2                 List of Windows installed Roles and Features
-\par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of\hich\af2\dbch\af31505\loch\f2  installed Microsoft Hotfixes and Updates for all
+\par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of installed Microsoft Hotfixes and Updates for all
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
-\par \hich\af2\dbch\af31505\loch\f2                 Appendix D List of Citrix installed components for all Controllers
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Appendix D List of Citrix installed components for all Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features for all Controllers
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DDC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
@@ -783,30 +787,30 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         CVADSiteName_Documentation_Appendix#_NameOfAppendix.csv
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         For example:
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixA_VDARegistryItems.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documen\hich\af2\dbch\af31505\loch\f2 tation_AppendixA_VDARegistryItems.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixB_ControllerRegistryItems.csv
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
-\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD_CitrixInstalledComponents.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixC_MicrosoftHotfixesandUpdates.csv
+\par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixD\hich\af2\dbch\af31505\loch\f2 _CitrixInstalledComponents.csv
 \par \hich\af2\dbch\af31505\loch\f2                 CVADSiteName_Documentation_AppendixE_WindowsInstalledComponents.csv
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required? \hich\af2\dbch\af31505\loch\f2                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives deta\hich\af2\dbch\af31505\loch\f2 iled information on all desktops in all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information on all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause t\hich\af2\dbch\af31505\loch\f2 he report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatal\hich\af2\dbch\af31505\loch\f2 ogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an \hich\af2\dbch\af31505\loch\f2 exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 has an alias of DG.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -814,21 +818,21 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups\hich\af2\dbch\af31505\loch\f2 Utilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 da\hich\af2\dbch\af31505\loch\f2 ys
 \par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Microsoft Excel to be locally installed.
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes\hich\af2\dbch\af31505\loch\f2  the report to take a longer
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter has an alias of DGU.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -838,22 +842,22 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file\hich\af2\dbch\af31505\loch\f2  is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         The end date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The format for date only is MM/DD/YYYY.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM\hich\af2\dbch\af31505\loch\f2 /DD/YYYY HH:MM:SS" in 24-hour format.
+\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour\hich\af2\dbch\af31505\loch\f2  format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
@@ -861,7 +865,7 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                (Get-Date -displayhint date)
+\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get\hich\af2\dbch\af31505\loch\f2 -Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -967,15 +971,15 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13401205\charrsid9520485 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
-\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
+\par \hich\af2\dbch\af31505\loch\f2         can take a \hich\af2\dbch\af31505\loch\f2 very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD-based policy information from the output document.
@@ -1206,9 +1210,10 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8211820 \hich\af2\dbch\af31505\loch\f2 30}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 December 17, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 Decem\hich\af2\dbch\af31505\loch\f2 ber 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8211820 
+\hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 , 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1568,29 +1573,29 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485\charrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Mac\hich\af2\dbch\af31505\loch\f2 hines in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
@@ -1607,14 +1612,14 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections, and Resources
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     S\hich\af2\dbch\af31505\loch\f2 ideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administr\hich\af2\dbch\af31505\loch\f2 ator for the User Name.
 \par 
 \par 
 \par 
@@ -1623,9 +1628,9 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485\charrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" \hich\af2\dbch\af31505\loch\f2 -UserName "Carl Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
@@ -1641,7 +1646,7 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alia\hich\af2\dbch\af31505\loch\f2 s CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
@@ -1649,13 +1654,13 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ---------------------\hich\af2\dbch\af31505\loch\f2 ----- EXAMPLE 24 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9520485\charrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>P\hich\af2\dbch\af31505\loch\f2 S C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax\hich\af2\dbch\af31505\loch\f2  "+44 1753 276600"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
@@ -1663,7 +1668,7 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Com\hich\af2\dbch\af31505\loch\f2 pany Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par 
@@ -1671,36 +1676,36 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScr\hich\af2\dbch\af31505\loch\f2 ipt .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9520485\charrsid9520485 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "D\hich\af2\dbch\af31505\loch\f2 r. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the\hich\af2\dbch\af31505\loch\f2  Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for th\hich\af2\dbch\af31505\loch\f2 e Company Email.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory_V2.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HH\hich\af2\dbch\af31505\loch\f2 mm.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 
  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
@@ -1709,15 +1714,15 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 27 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will us\hich\af2\dbch\af31505\loch\f2 e all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNam\hich\af2\dbch\af31505\loch\f2 e="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:user\hich\af2\dbch\af31505\loch\f2 name = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1727,25 +1732,25 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 
  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485\charrsid9520485 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wil\hich\af2\dbch\af31505\loch\f2 l be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15873118 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9520485\charrsid9520485 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.pdf
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\X\hich\af2\dbch\af31505\loch\f2 D7_Inventory_V2.ps1 -Hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $en\hich\af2\dbch\af31505\loch\f2 v:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrat\hich\af2\dbch\af31505\loch\f2 or for the User Name.
 \par 
 \par 
 \par 
@@ -1755,7 +1760,7 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="C\hich\af2\dbch\af31505\loch\f2 arl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1773,12 +1778,12 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer mail.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485\charrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld -To ITGroup@d\hich\af2\dbch\af31505\loch\f2 omain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company=\hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1786,26 +1791,26 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sending t\hich\af2\dbch\af31505\loch\f2 o ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to se\hich\af2\dbch\af31505\loch\f2 nd email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 31 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9520485\charrsid9520485 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster\hich\af2\dbch\af31505\loch\f2 @CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Sof\hich\af2\dbch\af31505\loch\f2 tware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1815,8 +1820,8 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
 \par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the curre\hich\af2\dbch\af31505\loch\f2 nt user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompt\hich\af2\dbch\af31505\loch\f2 ed to enter valid credentials.
 \par 
 \par 
 \par 
@@ -1825,15 +1830,15 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Policies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will us\hich\af2\dbch\af31505\loch\f2 e all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webst\hich\af2\dbch\af31505\loch\f2 er for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administr\hich\af2\dbch\af31505\loch\f2 ator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
 \par 
@@ -1845,14 +1850,14 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Web\hich\af2\dbch\af31505\loch\f2 ster" or
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Proce\hich\af2\dbch\af31505\loch\f2 sses only the Delivery Groups section of the report with Delivery Group details.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
 \par 
 \par 
 \par 
@@ -1862,9 +1867,9 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Section Groups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1879,52 +1884,52 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default \hich\af2\dbch\af31505\loch\f2 values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mic\hich\af2\dbch\af31505\loch\f2 rosoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Com\hich\af2\dbch\af31505\loch\f2 pany Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry\hich\af2\dbch\af31505\loch\f2  keys to the Controllers section.
+\par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to the Controllers section.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 36 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -VDARegistryKeys
+\par \hich\af2\dbch\af31505\loch\f2     PS C\hich\af2\dbch\af31505\loch\f2 :\\PSScript >.\\XD7_Inventory_V2.ps1 -VDARegistryKeys
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to Appendix A.
-\par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to $True
+\par \hich\af2\dbch\af31505\loch\f2     Forces the Machin\hich\af2\dbch\af31505\loch\f2 eCatalogs parameter to $True
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 37 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.\hich\af2\dbch\af31505\loch\f2 ps1 -MaxDetails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = A\hich\af2\dbch\af31505\loch\f2 dministrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
@@ -1935,10 +1940,10 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
-\par \hich\af2\dbch\af31505\loch\f2         Log\hich\af2\dbch\af31505\loch\f2 ging             = True
+\par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
+\par \hich\af2\dbch\af31505\loch\f2         Sto\hich\af2\dbch\af31505\loch\f2 reFront          = True
 \par \hich\af2\dbch\af31505\loch\f2         VDARegistryKeys     = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
@@ -1947,9 +1952,9 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 38 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 38 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Dev -S\hich\af2\dbch\af31505\loch\f2 criptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1961,14 +1966,14 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a tex\hich\af2\dbch\af31505\loch\f2 t file named XAXDV2InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV2InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains up to th\hich\af2\dbch\af31505\loch\f2 e last 250 errors reported by the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV2InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and ot\hich\af2\dbch\af31505\loch\f2 her basic information.
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     XDV2DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
+\par \hich\af2\dbch\af31505\loch\f2     XDV2Do\hich\af2\dbch\af31505\loch\f2 cScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
 \par 
 \par 
@@ -1977,9 +1982,9 @@ XD7_Inventory_V2.ps1 [-Text] [-AddDateTime] [-Adm\hich\af2\dbch\af31505\loch\f2 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -CSV
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Wil\hich\af2\dbch\af31505\loch\f2 l use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for ea\hich\af2\dbch\af31505\loch\f2 ch Appendix.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9520485 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -2101,10 +2106,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000e0e7
-52c11eb5d50103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000e0e752c11eb5d501
-e0e752c11eb5d501000000000000000000000000d400de00da00cd00d90034004d00d10042005500da00d40055004b00d800d000d400c300c800ca00560041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000e0e752c11eb5
-d501e0e752c11eb5d5010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000c009
+9066b1b6d50103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000b0e28f66b1b6d501
+c0099066b1b6d501000000000000000000000000ca0048004e0046004c00da004b005700c000d4003400d00044003200c7004600db00c400da00de00dc00c0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000b0e28f66b1b6
+d501c0099066b1b6d5010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -2112,7 +2117,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e78
 6d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c
 65637465645374796c653d225c415041536978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e00000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
-6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b45354144454544332d333145332d344530352d423435302d4145333044323341324135347d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b32463435373341382d393641322d343738332d423030442d4339433545453445424546327d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
 656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
 0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,14 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.30 19-Dec-2019
+#	Added additional VDA registry key data to Machine details for VDA 1912 (Known Issues for ADM hardware encoding)
+#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\MaxNumRefFrames
+#	Fixed - FINALLY - the issue of detecting the Site Version for comparison.
+#		CVAD 1909 and above show Multi-session OS and Single-session OS
+#		CVAD 1906 and below show Server OS and Desktop OS
+#	Tested with CVAD 1912
+
 #Version 2.29 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#Version 2.30 19-Dec-2019
#	Added additional VDA registry key data to Machine details for VDA 1912 (Known Issues for ADM hardware encoding)
#		HKLM:\SOFTWARE\Wow6432Node\Citrix\ICAClient\Engine\Configuration\Advanced\Modules\GfxRender\MaxNumRefFrames
#	Fixed - FINALLY - the issue of detecting the Site Version for comparison.
#		CVAD 1909 and above show Multi-session OS and Single-session OS
#		CVAD 1906 and below show Server OS and Desktop OS
#	Tested with CVAD 1912
